### PR TITLE
chore: harden biome and typescript strictness

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,16 +1,129 @@
 {
+  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "correctness": {
+        "noUndeclaredVariables": "error",
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error",
+        "noUnusedFunctionParameters": "error",
+        "noUndeclaredDependencies": "error"
+      },
+      "style": {
+        "noDefaultExport": "error",
+        "noNamespace": "error",
+        "noNegationElse": "error",
+        "noNonNullAssertion": "error",
+        "noParameterAssign": "error",
+        "useCollapsedElseIf": "error",
+        "useConsistentArrayType": {
+          "level": "error",
+          "options": {
+            "syntax": "generic"
+          }
+        },
+        "useDefaultSwitchClause": "error",
+        "useExplicitLengthCheck": "error",
+        "useForOf": "error",
+        "useFragmentSyntax": "error",
+        "useNamingConvention": {
+          "level": "error",
+          "options": {
+            "strictCase": false,
+            "conventions": [
+              {
+                "selector": {
+                  "kind": "function"
+                },
+                "formats": ["camelCase", "PascalCase"]
+              },
+              {
+                "selector": {
+                  "kind": "typeLike"
+                },
+                "formats": ["PascalCase"]
+              },
+              {
+                "selector": {
+                  "kind": "enumMember"
+                },
+                "formats": ["PascalCase"]
+              }
+            ]
+          }
+        },
+        "useThrowOnlyError": "error"
+      },
+      "suspicious": {
+        "noConsole": "error",
+        "noEmptyBlockStatements": "error",
+        "noEvolvingTypes": "error",
+        "noExplicitAny": "error",
+        "noMisplacedAssertion": "error",
+        "useAwait": "error"
+      },
+      "complexity": {
+        "noExcessiveCognitiveComplexity": {
+          "level": "error",
+          "options": {
+            "maxAllowedComplexity": 15
+          }
+        },
+        "noExcessiveNestedTestSuites": "error",
+        "useDateNow": "error",
+        "useSimplifiedLogicExpression": "error"
+      },
+      "performance": {
+        "noBarrelFile": "error",
+        "noReExportAll": "error"
+      }
     }
   },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
     "indentWidth": 2,
-    "lineWidth": 100
+    "lineWidth": 100,
+    "lineEnding": "lf"
   },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.config.ts", "**/*.config.mjs", "packages/config/*.ts", "apps/docs/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noDefaultExport": "off"
+          },
+          "correctness": {
+            "noUndeclaredDependencies": "off"
+          },
+          "performance": {
+            "noBarrelFile": "off",
+            "noReExportAll": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/scripts/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    }
+  ],
   "files": {
     "includes": [
       "**",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format": "biome format --write .",
     "clean": "turbo run clean",
     "typecheck": "turbo run typecheck",
+    "ci": "npm run lint && turbo run typecheck build test",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo run build && changeset publish",

--- a/packages/config/tsconfig/base.json
+++ b/packages/config/tsconfig/base.json
@@ -4,12 +4,24 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
+
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -13,7 +13,7 @@ export interface StreamdOptions {
  * Parse a markdown string into tokens.
  * This is a placeholder — real implementation coming soon.
  */
-export function parse(input: string, _options?: StreamdOptions): string[] {
+export function parse(input: string, _options?: StreamdOptions): Array<string> {
   if (!input) return [];
   return input.split("\n");
 }

--- a/packages/spec/src/spec.test.ts
+++ b/packages/spec/src/spec.test.ts
@@ -16,11 +16,11 @@ import { SKIP } from "./skip";
 
 // ── Stubs — replace with @streamd/parser imports ──
 
-function parse(_markdown: string): unknown[] {
+function parse(_markdown: string): Array<unknown> {
   return [];
 }
 
-function render(_tokens: unknown[]): string {
+function render(_tokens: Array<unknown>): string {
   return "NOT_YET_IMPLEMENTED";
 }
 
@@ -43,7 +43,7 @@ async function normalizeHtml(html: string): Promise<string> {
 
 // ── Discover .md/.html fixture pairs in a directory ──
 
-function discoverFixtures(directory: string): string[] {
+function discoverFixtures(directory: string): Array<string> {
   return readdirSync(directory)
     .filter((file) => file.endsWith(".md"))
     .sort()
@@ -78,6 +78,7 @@ for (const { name: suiteName, directory, skipKey } of suites) {
         const normalizedExpected = await normalizeHtml(expectedHtml);
 
         // TODO: flip to .toBe() once parser + renderer are implemented
+        // biome-ignore lint/suspicious/noMisplacedAssertion: testFn is it() or it.skip()
         expect(normalizedActual).not.toBe(normalizedExpected);
       });
     }


### PR DESCRIPTION
- Strict Biome linter rules at error level across all categories
- Hardened tsconfig with noUncheckedIndexedAccess, exactOptionalPropertyTypes, verbatimModuleSyntax, etc.
- Added ci script for one-command validation
- Fixed source files to comply with new rules