### PR TITLE
feat(parser): implement incremental streaming with O(K) fast paths

### DIFF
--- a/.kiro/steering/parser-conventions.md
+++ b/.kiro/steering/parser-conventions.md
@@ -138,10 +138,13 @@ Engineering standards, performance constraints, and code style conventions for `
 - Container assembly (`assembleBlockquote`) re-scans inner content with `scanBlocks` recursively, with a 100-level nesting depth guard.
 
 ### Streaming
-- `StreamState` tracks accumulated source, options, and last scan results.
-- Each chunk appends to source, re-scans complete lines with `scanBlocks`.
-- `parse("", state)` flushes by re-scanning the full accumulated source.
-- `stableCount = tokens.length - 1` (last block is speculative).
+- Streaming logic lives in `streaming/` module: `state.ts`, `fast-path.ts`, `incremental.ts`.
+- `StreamState` tracks previous source length, options, cached completed tokens/refMap, and active block metadata (kind, content start, fence info, cached inlines).
+- Caller passes the full accumulated source each time. Parser diffs against `prevLen` to detect new content, then applies fast paths or falls back to scanning the active block region.
+- Fast paths (checked in order): text-append O(K), fenced code O(K), math block O(K), paragraph continuation O(K)+O(N) inlines, full scan.
+- Completed blocks are promoted and cached; only the last (active) block is re-assembled speculatively.
+- No flush needed — the last call's tokens are final.
+- `stableCount = completedTokens.length` (last block is speculative).
 
 ### GFM Options Resolution
 - `gfm: true` enables `tables`, `strikethrough`, `taskListItems`, `autolinks` unless individually overridden.

--- a/.kiro/steering/parser-design.md
+++ b/.kiro/steering/parser-design.md
@@ -2,225 +2,501 @@
 inclusion: always
 ---
 
-# @streamd/parser — Design & Architecture
+# @streamd/parser — Design Document
 
-Reference document for the streaming markdown parser. Describes the public API, architecture, token model, file structure, and current implementation status.
+## 1. Problem Statement
 
-## Public API
+Render markdown in real-time as it streams from an LLM, token by token. Existing parsers (commonmark.js, markdown-it, marked, micromark) are batch-oriented — they accept a complete document and return a complete result. When used for streaming, the naive approach is to re-parse the entire accumulated document on every new token. For a 50KB response streamed in 1000 chunks, that's O(n²) total work.
 
-```ts
-function parse(src: string, state?: ParserState | null, options?: ParseOptions): ParseResult
+We need a parser that:
+- Produces a token tree (not HTML) for framework-agnostic rendering
+- Supports incremental parsing where per-chunk cost is proportional to new content, not accumulated document size
+- Indicates which tokens are finalized vs speculative
+- Matches CommonMark 0.31.2 + GFM 0.29 compliance
+- Runs in browsers and Node.js with no dependencies
+
+## 2. Why Not Use Existing Parsers?
+
+**commonmark.js / markdown-it / marked**: No streaming API. Must re-parse from scratch on every chunk. O(n²) total for streaming.
+
+**micromark**: Has a Node.js Duplex stream interface, but it buffers all chunks internally and only emits the final HTML on `end()`. The state machine processes characters incrementally, but `postprocess` (subtokenize — resolving content into flow/text) and `compile` (HTML generation) are batch operations that run once at the end. There is no way to get intermediate token output. Additionally, micromark outputs HTML strings, not a token tree.
+
+The core issue: none of these parsers were designed for the "render partial results as they arrive" use case that LLM streaming demands.
+
+## 3. Fundamental Constraints of Incremental Markdown Parsing
+
+Before describing our solution, it's important to understand what markdown's grammar makes theoretically possible and impossible for incremental parsing.
+
+### 3.1 What CAN Be O(K) Per Chunk
+
+**Literal-content blocks** (fenced code, math, HTML blocks types 1-5): Content between fences is literal text with no inline parsing. Each new line only needs to be checked for the closing delimiter — O(line_length). This is the strongest case for incremental parsing.
+
+**Block-level continuation detection**: Determining whether a new line continues the current block or starts a new one requires checking only the first non-space character of the line — O(line_length). The set of block-start characters is fixed and small.
+
+**Plain text append within a paragraph**: If new content contains no inline-special characters (`*`, `_`, `` ` ``, `[`, `!`, `<`, `&`, `\`, `~`, `$`, `\n`), the existing inline token tree is unchanged — just extend the last Text token's content. This is the overwhelmingly common case in LLM streaming (word-by-word output).
+
+### 3.2 What CANNOT Be O(K) Per Chunk
+
+**Delimiter resolution across a paragraph**: An emphasis opener `*` on line 1 might pair with a closer `*` on line 50. When the closer arrives, the resolver must scan backward through all open delimiters to find a match. The opener-bottom optimization makes this amortized O(n) over the paragraph lifetime, but a single chunk containing a closer can trigger O(D) work where D is the number of open delimiters. In practice D is small (typically 0-5), so this is effectively O(K) — but it's not guaranteed.
+
+**Link reference forward references**: `[foo]` in paragraph 1 might resolve to `[foo]: url` defined in paragraph 100. When the definition arrives, all previous `[foo]` references retroactively become links. True incremental parsing cannot resolve these without a second pass. Our trade-off: forward references from later chunks don't resolve in earlier emissions. This is documented and acceptable for streaming — the consumer re-renders as new tokens arrive.
+
+**Setext heading detection**: A paragraph retroactively becomes a heading when `===` or `---` appears on the next line. The paragraph token must remain speculative until the next line is seen. Our `stableCount` mechanism handles this — the last block is always speculative.
+
+**List tight/loose detection**: Whether a list renders with `<p>` tags depends on blank lines between items, which is only known when the list ends. This affects rendering but not token structure.
+
+### 3.3 The Honest Complexity Picture
+
+| Scenario | Per-chunk cost | Bottleneck |
+|----------|---------------|------------|
+| Plain text append (no special chars) | O(K) | Dispatch table scan of new chars |
+| Fenced code / math continuation | O(K) | Line scan for closing fence |
+| Paragraph continuation (block check) | O(K) | First-char check of new lines |
+| Paragraph continuation (inline re-parse) | O(N_para) | Full inline re-parse of paragraph |
+| New closer matches old opener | O(D) amortized | Delimiter backward scan |
+| Block transition (heading, code, etc.) | O(active_region) | Full scan of active block region |
+
+Where K = new content size, N_para = current paragraph length, D = open delimiter count.
+
+The paragraph inline re-parse is the main gap. We mitigate it with the text-append fast path (true O(K) for the common case), but when inline-special characters appear, we fall back to O(N_para). A future optimization could maintain the inline node pool across calls and only re-resolve delimiters incrementally — this would reduce the cost to O(K + D) in all cases.
+
+## 4. Architecture
+
+### 4.1 Why Flat Scan-to-Completion?
+
+The traditional CommonMark approach (used by commonmark.js) maintains an "open block stack" and processes input line by line. Each line is checked against every open container block to see if it continues. This is correct but has two costs:
+1. Per-line overhead proportional to container nesting depth
+2. Complex mutable state that's hard to snapshot/restore for streaming
+
+Our approach: each block type has a dedicated scanner that consumes the entire block in a tight loop. `scanBlocks` classifies the first line, dispatches to the scanner, and the scanner runs until the block ends. The output is a flat `Array<Block>` — no tree, no open stack.
+
+**Trade-off**: This makes blockquote lazy continuation approximate. In the traditional approach, a line without `>` continues a blockquote only when the innermost open block is a paragraph. In our flat approach, any non-blank, non-block-start line continues a blockquote. This is a spec deviation (§5.1) that doesn't affect real-world markdown.
+
+**Why this is faster**: The tight per-block loops have excellent branch prediction and cache locality. The traditional per-line approach has a branch for every open container on every line. For deeply nested blockquotes or lists, the per-line approach does O(depth) work per line; ours does O(1) per line within a block.
+
+### 4.2 Why Pass Full Source Instead of Chunks?
+
+Markdown blocks can span many lines. A fenced code block might start on line 1 and end on line 1000. If we received chunks, we'd need to buffer them internally anyway to re-scan the active block. By having the caller pass the full accumulated source, we:
+1. Avoid internal buffering and string concatenation
+2. Can use `String.indexOf` (SIMD-accelerated in V8) on the full string
+3. Can diff against `prevLen` to identify new content in O(1)
+4. Give the caller control over memory management
+
+The caller is already accumulating the source (it's the LLM response). Passing it directly avoids a copy.
+
+### 4.3 Processing Pipeline
+
+```
+Full parse:
+  src → scanBlocks → Array<Block> → assemble → TokensList
+
+Streaming parse:
+  src + state → diff prevLen → fast-path cascade → TokensList + state'
+
+Fast-path cascade (checked in order):
+  1. Text append     — extend last Text token                    O(K)
+  2. Fenced code     — check new lines for closing fence         O(K)
+  3. Math block      — check new lines for closing $$            O(K)
+  4. Paragraph cont. — skip block scan, re-parse inlines         O(K) + O(N_para)
+  5. Full scan       — scanBlocks on active region               O(active_region)
 ```
 
-- `state` is null/undefined for full document parse, or a previous `ParserState` for streaming continuation.
-- `parse("", state)` flushes all open blocks and finalizes output.
-- `stableCount` indicates how many leading tokens are finalized and won't change in future chunks.
-- Forward references from later chunks won't resolve in earlier emissions (documented trade-off).
+### 4.4 Why These Fast Paths Are Safe
 
-### ParseOptions
+Each fast path has a conservative gatekeeper that can produce false negatives (fall back to full scan) but never false positives (miss a structural change). This is the key correctness invariant.
+
+- **Text append**: `isPlainTextAppend` checks every new byte against the inline dispatch table. If ANY byte maps to a non-zero handler, we fall back. This is correct because the dispatch table is the same one `parseInlines` uses — if no byte triggers a handler, the inline parse result is guaranteed to be "existing tokens + extended last Text".
+
+- **Fenced code**: `hasFenceClose` checks new lines for the exact closing fence pattern (indent < 4, >= fenceLen of fenceChar, then only whitespace). This mirrors the logic in `scanFencedCode`. If the check says "no close", the block is guaranteed to still be open.
+
+- **Paragraph continuation**: `isParagraphContinuation` checks new lines for blank lines, block-start characters, and setext underlines. The block-start character set is a superset of what `isNewBlockStart` in `para.ts` checks — we're more conservative (e.g., we reject any line starting with `-` even if it's not actually a valid list marker), which means we might fall back unnecessarily but never miss a real block transition.
+
+## 5. Critical Design Questions
+
+### Q1: Why not a state machine like micromark?
+
+micromark's state machine processes one character at a time with `consume`/`enter`/`exit` effects. This is elegant and spec-compliant but has costs: (1) function call per character (state transition), (2) complex construct resolution with attempt/check/interrupt, (3) no SIMD acceleration for bulk text. Our dispatch table approach processes ~80% of characters (plain text) in a tight `while` loop with no function calls, then dispatches to handlers only for special characters. Benchmarks show ~4x throughput advantage.
+
+### Q2: Is `String.indexOf("\n")` really faster than a hand-written loop?
+
+Yes. V8's `String.indexOf` for single-character search on one-byte strings uses SIMD instructions (SSE4.2/AVX2 on x86, NEON on ARM). A hand-written `while (src.charCodeAt(pos) !== 10) pos++` loop processes one byte per iteration. `indexOf` processes 16-32 bytes per instruction. For line scanning (the hottest operation in block parsing), this is a 10-20x speedup on the inner loop.
+
+### Q3: What happens when the fast-path check itself becomes the bottleneck?
+
+The text-append fast path scans every new byte against the dispatch table — O(K). For very small chunks (1-3 bytes, typical LLM tokens), this is ~3 table lookups. The overhead of the fast-path check is negligible compared to the cost it avoids (scanBlocks + parseInlines). For large chunks, the fast path is less likely to apply (more chance of special characters), so we naturally fall back to the full path which is appropriate for large inputs.
+
+### Q4: Is the `as unknown as ParserState` cast hiding a design problem?
+
+Yes, partially. `ParserState` is an opaque branded type in the public API to prevent consumers from constructing or inspecting it. Internally, it's a `StreamState` with concrete fields. The cast is the boundary between public opacity and internal access. An alternative would be a `WeakMap<ParserState, StreamState>` lookup, but that adds allocation and indirection on every call. The cast is zero-cost at runtime.
+
+### Q5: What's the memory profile?
+
+The parser holds: (1) the source string (owned by caller), (2) `completedTokens` array (grows monotonically), (3) `refMap` for link reference definitions, (4) `activeInlines` cache (replaced on each call). The `NODE_POOL` is module-level and never shrunk — it grows to the high-water mark of inline nodes in any single `parseInlines` call. For a 50KB document, typical memory overhead is ~200KB (tokens + pool). The pool is shared across all parse calls, so multiple concurrent streams would corrupt it — single-threaded use only.
+
+### Q6: Can the streaming state grow unboundedly?
+
+`completedTokens` grows by one token per completed block. For a document with N blocks, this is O(N) tokens. Each token is a small object (2-5 fields). For a 50KB document with ~200 blocks, this is ~200 token objects — negligible. The `refMap` grows by one entry per link reference definition — typically < 50 entries. The `NODE_POOL` is bounded by the largest paragraph's inline node count, not document size.
+
+### Q7: Could we use a rope or gap buffer instead of string concatenation?
+
+The caller accumulates the source via `+=` (string concatenation). In V8, this creates a ConsString (rope-like internal representation) that's flattened on first indexed access. Our `String.indexOf` and `charCodeAt` calls trigger flattening, so the effective cost is one memcpy per call. A rope data structure would avoid this copy but would prevent `indexOf` SIMD acceleration (which requires contiguous memory). The copy is O(n) but with a very small constant (memcpy is ~10GB/s). For a 50KB document, that's ~5µs — negligible compared to parsing.
+
+### Q8: Can we achieve true O(K) for paragraph inline parsing?
+
+Yes, with incremental delimiter tracking. The approach:
+1. Persist the `NODE_POOL` state across streaming calls (currently reset each call)
+2. On new content, scan only the new bytes, appending to the existing pool
+3. Run delimiter resolution only on new nodes + open delimiters from previous calls
+4. The opener-bottom tracking naturally prevents re-scanning committed regions
+
+This would reduce paragraph inline cost from O(N_para) to O(K + D) where D is open delimiter count (typically 0-5). The implementation complexity is moderate — the main challenge is handling the case where a new closer matches an old opener, requiring restructuring of already-emitted tokens. This is a future optimization.
+
+### Q9: What about concurrent/parallel parsing?
+
+Not supported. Module-level shared state (`NODE_POOL`, `IND` objects, `DISPATCH_CACHE`) means concurrent calls corrupt each other. For the LLM streaming use case, this is fine — each stream is sequential. If concurrent parsing were needed, the shared state would need to be moved into the `StreamState` object (at the cost of per-call allocation).
+
+### Q10: Is the paragraph inline re-parse actually a problem in practice?
+
+For LLM streaming: usually not. LLM tokens are 1-5 bytes. The text-append fast path handles ~70-80% of tokens (plain words/spaces). When inline-special characters appear (e.g., `**bold**`), the paragraph is typically short (< 1KB) and the inline re-parse takes < 50µs. The fast path avoidance of scanBlocks (which would otherwise re-scan the entire active region) is the bigger win. The inline re-parse becomes a concern only for very long paragraphs (> 10KB) with frequent special characters — an unusual pattern in LLM output.
+
+## 6. Module Reference
+
+### 6.1 API Layer
+
+| File | Lines | Role |
+|------|-------|------|
+| `parser.ts` | 85 | `parse`, `createParser`, options resolution. Delegates streaming to `streaming/`. |
+| `index.ts` | 43 | Public re-exports. No logic. |
+
+### 6.2 Type System
+
+| File | Lines | Role |
+|------|-------|------|
+| `types/token-type.ts` | 40 | Dense integer constants 0–22 (`as const`, not `const enum`). |
+| `types/tokens.ts` | 163 | 23 token interfaces. Discriminated union on `type`. All fields always present. |
+| `types/options.ts` | 42 | `ParseOptions`, `ParserState` (opaque branded), `ParseResult`. |
+| `types/internal.ts` | 44 | `InlineNode`, `ScanResult`, `LinkReference`. Not public. |
+| `types/block-type.ts` | 30 | Deprecated public block type mapping. |
+
+### 6.3 Block Scanning
+
+| File | Lines | Role |
+|------|-------|------|
+| `scanner/block/scan.ts` | 180 | `scanBlocks` — outer dispatch loop. Classifies first char, delegates to scanners. |
+| `scanner/block/leaf.ts` | 252 | ATX heading, fenced code, indented code, thematic break, HTML block, math block. |
+| `scanner/block/para.ts` | 271 | Paragraph scanner with setext heading and table detection on continuation lines. |
+| `scanner/block/container.ts` | 69 | Blockquote scanner — stores content range for deferred inner parsing. |
+| `scanner/block/list.ts` | 143 | List scanner with ordered/unordered detection, 9-digit limit. |
+| `scanner/block/html.ts` | 319 | HTML block open/close detection for types 1-7. Hand-written tag matching. |
+| `scanner/block/table-separator.ts` | 80 | GFM table separator validation. Returns alignment array. Max 128 columns. |
+| `scanner/block/types.ts` | 94 | `Block` record (monomorphic, ~16 fields), `BlockKind` constants, `createBlock` factory. |
+| `scanner/block/utils.ts` | 94 | `findLineEndFast` (SIMD via indexOf), `nextLine`, `countIndent`, `isBlankRange`. |
+
+### 6.4 Inline Scanning
+
+| File | Lines | Role |
+|------|-------|------|
+| `scanner/inline/scan.ts` | 295 | `parseInlines` — dispatch loop + `NODE_POOL` management. Two-pass: scan then resolve. |
+| `scanner/inline/dispatch.ts` | 78 | `Uint8Array(128)` dispatch table. Cached per feature-flag combination (3-bit key). |
+| `scanner/inline/emphasis.ts` | 69 | `scanDelimiterRun` — `canOpen`/`canClose` classification per spec §6.2. |
+| `scanner/inline/code.ts` | 111 | Code span scanner. Multi-backtick, content normalization, 32-backtick limit. |
+| `scanner/inline/link.ts` | 173 | Link/image scanner. Inline, reference, collapsed, shortcut forms. |
+| `scanner/inline/autolink.ts` | 308 | Spec autolinks + GFM extended autolinks. Hand-written URL validation. |
+| `scanner/inline/html.ts` | 279 | Inline HTML tags, comments, PIs, CDATA, declarations. |
+| `scanner/inline/entity.ts` | 47 | `&name;` and `&#decimal;`/`&#xhex;` entities. Named → raw text, numeric → decoded. |
+| `scanner/inline/escape.ts` | 47 | Backslash escapes for ASCII punctuation. |
+| `scanner/inline/math.ts` | 57 | `$...$` inline math. |
+
+### 6.5 Resolution
+
+| File | Lines | Role |
+|------|-------|------|
+| `resolver/delimiters.ts` | 267 | Spec §Appendix emphasis algorithm. Opener-bottom tracking. Rule-of-three. Strikethrough (pairs of 2). |
+| `resolver/references.ts` | 248 | Link reference definition scanning. Destination/title parsing. Label normalization. |
+
+### 6.6 Assembly
+
+| File | Lines | Role |
+|------|-------|------|
+| `assembler/assemble.ts` | 236 | Top-level assembly. Link ref def extraction. Block dispatch. Fenced/indented code content extraction. |
+| `assembler/container.ts` | 295 | Blockquote (prefix stripping + recursive re-parse, 100-depth guard). List (item parsing, tight/loose, task checkboxes). |
+| `assembler/table.ts` | 114 | GFM table. Pipe-delimited cell splitting. Per-cell inline parsing. |
+
+### 6.7 Streaming
+
+| File | Lines | Role |
+|------|-------|------|
+| `streaming/state.ts` | 67 | `StreamState` interface. `createInitialState`. `resetActiveState`. |
+| `streaming/fast-path.ts` | 190 | Gatekeeper functions: `isParagraphContinuation`, `isPlainTextAppend`, `hasFenceClose`, `hasMathClose`. |
+| `streaming/incremental.ts` | 307 | `streamingParse` — fast-path cascade, block promotion, speculative assembly. |
+
+### 6.8 Utilities
+
+| File | Lines | Role |
+|------|-------|------|
+| `scanner/constants.ts` | 187 | `CC_*` char codes, `CF_*` flags, `CHAR_TABLE` (Uint8Array), HTML tag sets. |
+| `scanner/utils.ts` | 76 | Character classification. All ≤10 lines for JIT inlining. |
+| `utils/token-factory.ts` | 171 | 23 monomorphic factory functions. One hidden class per token type. |
+| `utils/entities.ts` | 153 | Named/numeric entity scanning and decoding. |
+| `utils/normalize.ts` | 102 | Label normalization, backslash/entity unescaping. |
+
+## 7. Token Model
+
+### Block Tokens (0–9)
+
+| ID | Type | Key Fields |
+|----|------|------------|
+| 0 | Blockquote | children: Token[] |
+| 1 | List | ordered, start, tight, children: ListItemToken[] |
+| 2 | ListItem | checked: bool\|null, children: Token[] |
+| 3 | Heading | level: 1-6, children: InlineToken[] |
+| 4 | Paragraph | children: InlineToken[] |
+| 5 | CodeBlock | lang, info, content |
+| 6 | HtmlBlock | content |
+| 7 | Hr | — |
+| 8 | Space | — |
+| 9 | Table | align[], head[][], rows[][][] |
+
+### Inline Tokens (10–22)
+
+| ID | Type | Key Fields |
+|----|------|------------|
+| 10 | Text | content |
+| 11 | Softbreak | — |
+| 12 | Hardbreak | — |
+| 13 | CodeSpan | content |
+| 14 | Em | children: InlineToken[] |
+| 15 | Strong | children: InlineToken[] |
+| 16 | Strikethrough | children: InlineToken[] |
+| 17 | Link | href, title, children: InlineToken[] |
+| 18 | Image | src, alt, title |
+| 19 | HtmlInline | content |
+| 20 | Escape | content |
+| 21 | MathInline | content |
+| 22 | MathBlock | content |
+
+## 8. Streaming State
 
 ```ts
-interface ParseOptions {
-  gfm?: boolean             // Enables tables, strikethrough, taskListItems, autolinks
-  tables?: boolean           // Default: follows gfm
-  strikethrough?: boolean    // Default: follows gfm
-  taskListItems?: boolean    // Default: follows gfm
-  autolinks?: boolean        // Default: follows gfm
-  math?: boolean             // Enable $..$ inline, $$...$$ block
+interface StreamState {
+  prevLen: number              // Previous source length — for diff detection
+  opts: AssembleOpts           // Frozen parse options
+  completedTokens: Token[]     // Promoted (finalized) block tokens
+  activeBlockStart: number     // Offset where the active block begins
+  refMap: Map<string, LinkRef> // Accumulated link reference definitions
+  activeBlockKind: BlockKind   // Kind of the last active block
+  activeContentStart: number   // Content start offset (into full source)
+  activeFenceChar: number      // Fence char for code/math (0 if N/A)
+  activeFenceLen: number       // Fence length for code blocks (0 if N/A)
+  activeLang: string           // Language for fenced code
+  activeInfo: string           // Info string for fenced code
+  activeInlines: InlineToken[] // Cached inlines for text-append fast path
 }
 ```
 
-`gfm: true` enables all sub-features unless individually overridden to `false`.
+## 9. Performance Characteristics
 
-## Spec Basis
+### Engine Optimizations Leveraged
 
-CommonMark 0.31.2 + GFM 0.29.
+- **V8 SIMD**: `String.indexOf("\n")` uses SSE4.2/AVX2 for 16-32 byte parallel search
+- **Monomorphic ICs**: All records created via factories with fixed field order → one hidden class per type
+- **JIT inlining**: Character classification functions ≤10 lines → inlined at call sites
+- **Typed array indexing**: `Uint8Array` dispatch tables → bounds-checked but no boxing
+- **Pool reuse**: `NODE_POOL` avoids GC pressure from inline node allocation
 
-## Architecture
+### Pathological Input Protection
 
-### Flat Scan-to-Completion
+| Limit | Value | Rationale |
+|-------|-------|-----------|
+| Code span backtick max | 32 | Prevents O(n²) backtick scanning |
+| Table max columns | 128 | Prevents O(n) column allocation |
+| Max nesting depth | 100 | Prevents stack overflow in recursive assembly |
+| Ordered list digits | 9 | Spec §5.2 compliance |
+| Delimiter resolution | Opener-bottom tracking | Prevents O(n²) backward scanning |
 
-Full document parsing uses a flat scan-to-completion architecture. Instead of per-line open-stack processing (the traditional CommonMark approach), each block type is consumed in a tight loop from start to finish.
-
-**Phase 1 — Block Scanning** (`scanBlocks`):
-1. Classify the first line of each block by its leading character
-2. Dispatch to a block-type-specific scanner that consumes the entire block
-3. Produce a flat `Array<Block>` — no tree, no open stack, no per-line container walk
-4. Container blocks (blockquotes, lists) store content ranges only
-
-**Phase 2 — Assembly** (`assemble`):
-1. Extract link reference definitions from paragraph blocks (returns consumed index set)
-2. Walk the flat block array, dispatch on `BlockKind` integer
-3. Leaf blocks: parse inlines directly from source ranges
-4. Container blocks: strip prefixes, re-scan inner content with `scanBlocks`, recurse
-
-**Key performance characteristics:**
-- `findLineEndFast` uses `String.indexOf("\n")` — V8 SIMD-accelerated
-- `Block` record has ~16 fields, monomorphic shape, no dynamic arrays
-- No open-stack walk per line — blocks consumed in tight loops
-- Inline dispatch via `Uint8Array(128)` with bulk plain-text skip
-- `NODE_POOL` reused across `parseInlines` calls (never shrunk)
-
-### Streaming
-
-Both full and streaming parse use the same flat architecture. Streaming accumulates source chunks and re-scans complete lines with `scanBlocks` on each chunk. The last block is speculative (may continue with the next chunk). `parse("", state)` flushes by re-scanning the full accumulated source.
-
-### Inline Parsing
-
-`parseInlines` scans content char-by-char via `Uint8Array(128)` dispatch table:
-1. `dispatch[code] === 0` → text, bulk skip (the fast path)
-2. Non-zero → switch to handler (escape, code span, delimiter, link, image, autolink, entity, newline, math, GFM autolink)
-3. `resolveDelimiters` — opener-bottom tracking, linear-amortized
-4. Compaction — sweep dead nodes, produce `Array<InlineToken>`
-
-Dispatch tables defined in `inline/dispatch.ts`, lazily cached per `(math, autolinks, strikethrough)` combination (3-bit key, up to 8 variants).
-
-### Block Rule Precedence
-
-1. Indented code — indent >= 4
-2. Math block (`$$`) — when math enabled
-3. ATX heading (`#`)
-4. Fenced code (`` ` `` or `~`)
-5. Thematic break (`-`, `*`, `_`)
-6. Blockquote (`>`)
-7. Unordered list (`-`, `*`, `+` + space)
-8. Ordered list (1-9 digits + `.`/`)` + space, max 9 digits per spec §5.2)
-9. Table (`|` + separator on next line) — when tables enabled
-10. HTML block (`<`)
-11. Paragraph (with setext heading and table detection on continuation lines)
-
-**Paragraph interruption rules:**
-- Indented code cannot interrupt a paragraph (4+ indent is lazy content)
-
-## Token Model
-
-### Block tokens (0–9)
-Blockquote, List, ListItem, Heading, Paragraph, CodeBlock, HtmlBlock, Hr, Space, Table
-
-### Inline tokens (10–22)
-Text, Softbreak, Hardbreak, CodeSpan, Em, Strong, Strikethrough, Link, Image, HtmlInline, Escape, MathInline, MathBlock
-
-All token interfaces have ALL fields always present (monomorphic shapes).
-
-## Internal Records
-
-- `Block` — ~16 fields, monomorphic. Created via `createBlock`. Never mutated after scanning (consumed blocks tracked via `Set<number>` in assembler).
-- `BlockKind` — dense integer block kind constants (0–11).
-- `InlineNode` — first-pass inline scan output (kind: 0=token, 1=delimiter, 2=dead).
-- `ScanResult` — shared interface for inline sub-scanner return values.
-- `LinkReference` — stored in refMap (first definition wins).
-- `NODE_POOL` — module-level `Array<InlineNode>`, never shrunk, reused across all `parseInlines` calls.
-- `StreamState` — internal streaming state: accumulated source, options, last blocks, refMap.
-
-## File Structure
-
-```
-packages/parser/src/
-  types/
-    token-type.ts           — TokenType as const (dense integers 0–22)
-    block-type.ts           — BlockType (deprecated public API export, not used internally)
-    tokens.ts               — 23 public token interfaces + Align type
-    internal.ts             — InlineNode, ScanResult, LinkReference
-    options.ts              — ParseOptions, ParseResult, ParserState
-  scanner/
-    constants.ts            — CC_* char codes, CF_* flags, CHAR_TABLE, HTML_BLOCK_TAGS, HTML_TYPE1_TAGS
-    utils.ts                — isAlpha, isAsciiWhitespace, isPunctuation, isUnicodeWhitespace, skipSpaces
-    block/
-      types.ts              — Block, BlockKind, BlockKindValue, createBlock
-      utils.ts              — findLineEndFast, nextLine, countIndent, isBlankRange, isSpaceOrTab
-      scan.ts               — scanBlocks
-      leaf.ts               — scanAtxHeading, scanFencedCode, scanIndentedCode, scanThematicBreak, scanHtmlBlock, scanMathBlock
-      para.ts               — scanParagraph (setext heading + table detection)
-      container.ts          — scanBlockquote
-      list.ts               — scanList, isOrderedListStart
-      html.ts               — matchHtmlBlockOpen, matchHtmlBlockClose
-      table-separator.ts    — tryTableSeparator
-    inline/
-      dispatch.ts           — selectDispatch, H_* handler index constants
-      scan.ts               — parseInlines, pushToken, NODE_POOL
-      emphasis.ts           — scanDelimiterRun
-      code.ts               — scanCodeSpan
-      link.ts               — scanLinkOrImage
-      autolink.ts           — scanAutolink, scanGfmAutolink, matchProtocolPrefix
-      html.ts               — scanHtmlInline
-      entity.ts             — scanEntity
-      escape.ts             — scanEscape
-      math.ts               — scanMathInline
-  resolver/
-    delimiters.ts           — resolveDelimiters
-    references.ts           — scanLinkRefDef, parseLinkDestination, parseLinkTitle
-  assembler/
-    assemble.ts             — assemble, assembleBlock, extractAllLinkRefDefs, AssembleOpts
-    container.ts            — assembleBlockquote, assembleList (with 100-level nesting guard)
-    table.ts                — assembleTable
-  utils/
-    token-factory.ts        — 23 monomorphic factory functions
-    entities.ts             — scanNamedEntity, scanNumericEntity
-    normalize.ts            — normalizeLabel, unescapeString
-  parser.ts                 — parse, createParser, resolveOptions, StreamState
-  index.ts                  — public exports
-
-packages/bench/                — standalone benchmark package
-  src/
-    index.ts                — CLI entry (--compare, --profile flags)
-    generate.ts             — test input generators
-    runner.ts               — bench harness (median, p95, throughput)
-```
-
-## Implementation Status
-
-### Complete
-- Flat scan-to-completion block architecture (full parse + streaming)
-- All CommonMark block types: ATX/setext headings, fenced/indented code, blockquotes, lists, HTML blocks (types 1-7), thematic breaks, paragraphs, link reference definitions
-- All CommonMark inline types: emphasis/strong (rule-of-three), code spans, links (inline/reference/collapsed/shortcut), images, autolinks, HTML inline, entities (numeric decoded, named as raw text), escapes, hard/soft breaks
-- GFM strikethrough (`~~`, pairs of exactly 2)
-- GFM task list items (`- [ ]`, `- [x]`)
-- GFM extended autolinks (bare `http://`, `https://`, `www.`)
-- GFM tables (pipe-delimited with alignment, max 128 columns)
-- Math extension (`$..$` inline, `$$...$$` block)
-- Streaming with stableCount (flat re-scan architecture)
-- Options resolution (`gfm` cascades to sub-features, each independently toggleable)
-- Ordered list 9-digit limit enforced (spec §5.2)
-- Max nesting depth 100 for recursive container assembly
-- 464 unit tests across 29 test files, 95.7% statement coverage
-
-### Not Yet Implemented
-- Conformance test harness (packages/spec wiring against CommonMark spec examples)
-- HTML renderer (packages/html)
-- Null byte replacement with U+FFFD (spec §2.3)
-
-### Known Limitations
-- **Bare CR before LF**: if a bare CR appears before an LF on the same line (e.g., `abc\rX\ndef`), the bare CR is not detected as a line ending. This is a spec §2.1 edge case that doesn't occur in real-world markdown. Bare CR without any LF on the line IS correctly handled.
-- **Blockquote lazy continuation**: approximate — any non-blank, non-block-start line continues a blockquote, rather than only when the innermost open block is a paragraph (spec §5.1). This is a trade-off of the flat architecture.
-- **Streaming O(n²)**: re-scans the full accumulated source on each chunk. Acceptable for typical streaming (LLM token-by-token) but not optimal for byte-at-a-time feeding of very large documents.
-- **Named HTML entities**: emitted as raw text tokens — entity resolution is a renderer concern. Numeric entities are decoded since the code point is unambiguous.
-- **Entity validation**: accepts any alphanumeric name + `;` — does not verify against the HTML5 entity list.
-- **Thread safety**: module-level shared state (`NODE_POOL`, `IND`, `DISPATCH_CACHE`) means concurrent calls from multiple async contexts would corrupt each other. Single-threaded use only.
-
-## Pathological Input Protection
-
-| Limit | Value |
-|-------|-------|
-| Code span backtick max | 32 |
-| Table max columns | 128 |
-| Max nesting depth | 100 |
-| Ordered list digits | 9 (spec §5.2) |
-| Delimiter resolution | Opener-bottom tracking (linear-amortized) |
-
-## Performance
+### Benchmarks
 
 | Input | Size | Throughput |
 |-------|------|-----------|
-| Mixed markdown | 1KB | ~80 MB/s |
-| Mixed markdown | 50KB | ~100 MB/s |
-| Mixed markdown | 500KB | ~83 MB/s |
-| Pathological (`*` x 10000) | 10KB | < 0.1ms |
+| Mixed markdown | 1 KB | ~80 MB/s |
+| Mixed markdown | 50 KB | ~100 MB/s |
+| Mixed markdown | 500 KB | ~83 MB/s |
+| Pathological (`*` × 10000) | 10 KB | < 0.1ms |
 
-### Comparative (500KB mixed markdown)
-
-| Parser | Throughput |
-|--------|-----------|
+| Parser | 500 KB Throughput |
+|--------|-------------------|
 | @streamd/parser | ~83 MB/s |
 | commonmark.js | ~22 MB/s |
 | markdown-it | ~22 MB/s |
 | marked | ~14 MB/s |
+
+## 10. Toward True O(K): Incremental Inline Architecture
+
+This section describes how to eliminate the O(N_para) inline re-parse — the last remaining non-O(K) cost in the streaming path. This is a design proposal, not yet implemented.
+
+### 10.1 The Bottleneck Is Redundant Work, Not a Fundamental Limitation
+
+Nothing in markdown's grammar prevents O(K) incremental parsing for the streaming case. The consumer already handles speculative tokens — it re-renders `tokens[stableCount..]` on every chunk. The parser's job is to produce a correct token tree for the active block. The question is how much work that requires.
+
+Currently, we re-parse ALL inlines from `contentStart` on every chunk that contains special characters. For a 10KB paragraph receiving 3-byte chunks with occasional `*`, each chunk does ~10KB of inline scanning work. Over 3000 chunks, that's 30MB of redundant scanning — re-doing work we've already done.
+
+The redundancy has three layers:
+1. **Inline scanning**: Re-scanning chars we've already classified into InlineNodes
+2. **Delimiter resolution**: Re-running the opener/closer matching algorithm on nodes we've already resolved
+3. **Output compaction**: Re-building the InlineToken[] array from nodes that haven't changed
+
+All three layers can be made incremental.
+
+### 10.2 Key Insight: Delimiter Resolution Is Already Amortized
+
+The opener-bottom tracking in `resolveDelimiters` prevents re-scanning past previously failed positions. Each opener is visited at most once as a potential match for each closer type. Over the lifetime of a paragraph, total delimiter resolution work is O(N_para) regardless of how many chunks it arrives in.
+
+If we persist the delimiter state across calls, the per-chunk resolution cost is O(D_new) where D_new is the number of new delimiter nodes in the chunk — typically 0-2.
+
+### 10.3 Proposed Architecture
+
+```
+StreamState gains:
+  inlinePool: InlineNode[]     // Persistent across calls (like NODE_POOL but per-stream)
+  inlinePoolCount: number      // Current node count in pool
+  inlineScanPos: number        // Where inline scanning left off (offset into src)
+  openerBottom: {              // Persistent opener-bottom state
+    star: [number, number, number]
+    underscore: [number, number, number]
+    tilde: [number, number, number]
+  }
+```
+
+**Per-chunk flow for paragraph with special chars:**
+
+```
+1. Block check: scan new lines for block-start chars           O(K)
+   → paragraph continues
+
+2. Inline scan: scan src[inlineScanPos..lastComplete]          O(K)
+   → append new InlineNodes to inlinePool
+   → update inlineScanPos
+
+3. Delimiter resolution: process new nodes only                O(D_new) amortized
+   → for each new closer: backward scan from openerBottom
+   → when match found: wrap tokens between opener and closer
+   → update openerBottom
+
+4. Speculative closure: produce token for the active block     O(pool_size)
+   → paragraph: compact pool into InlineToken[], auto-close open delimiters
+   → fenced code/math: slice content range, no inline work
+   → container: re-parse inner content (rare in LLM streaming)
+   → this is output assembly, not parsing — consumer iterates full array anyway
+```
+
+### 10.4 Speculative Closure of Active Blocks
+
+The consumer needs renderable tokens for the active block even though it's not finalized. Different block types have different speculative closure costs:
+
+**Paragraph**: Compact the inline pool into `InlineToken[]`. Unmatched openers become literal text or auto-closed emphasis (existing `autoCloseOpeners` logic). Cost: O(pool_size) — but this is output assembly. The parsing work (steps 1-3) was O(K + D_new).
+
+**Fenced code / math**: Emit the token with content from `activeContentStart` to current position. No inline parsing. O(1) token construction + O(content_size) for the `src.slice()`. The slice is unavoidable — the consumer needs the content string.
+
+**HTML block**: Same as fenced code — literal content, just slice and emit.
+
+**Heading**: Headings are single-line blocks. They're completed and promoted on the same call they're detected. Never speculatively open.
+
+**Blockquote / list (containers)**: These require re-parsing inner content for speculative closure. However, containers are rarely the active block in LLM streaming — they become completed when a blank line or block transition occurs. When they ARE active (e.g., streaming `> line1\n> line2\n> line3`), the inner content must be re-parsed on each chunk. This is O(inner_content) — not O(K). But this is inherent to containers: their token tree depends on the full inner content structure, which can change with each new line (a new inner block might start).
+
+**The practical impact**: In LLM streaming, the active block is almost always a leaf (paragraph ~70%, fenced code ~25%, other ~5%). Containers become active only briefly during transitions. The O(inner_content) cost for container speculative closure is real but rare.
+
+### 10.5 Dirty-Range Compaction Optimization
+
+The O(pool_size) compaction in step 4 can be reduced. Track a `dirtyStart` index — the first pool node modified since the last compaction. Nodes before `dirtyStart` produced the same tokens as last time. Only re-compact from `dirtyStart` forward, splicing the new tokens into the cached array.
+
+For the common case (new text appended, no delimiter matches), `dirtyStart` equals the previous pool count — we only compact the new nodes and append them. This makes compaction O(K_nodes) where K_nodes is the number of new inline nodes, not the total pool size.
+
+When a delimiter match restructures old nodes (wrapping tokens between opener and closer), `dirtyStart` moves back to the opener position. The re-compaction covers the affected range. This is O(affected_range) — proportional to the distance between opener and closer, which is bounded by the paragraph content between them.
+
+**Total parsing work per chunk: O(K + D_new)**. The compaction in step 4 is O(pool_size) but this is output assembly, not parsing — the consumer will iterate the full children array to render the paragraph, so this cost is matched by consumption cost.
+
+### 10.6 Why This Works
+
+The critical correctness property: **the active block's tokens are always speculative**. They're not in `completedTokens`. The consumer gets them as `tokens[stableCount..]` and knows they may change. So when a new closer matches an old opener and restructures the token tree, the consumer simply re-renders the speculative region — which it was going to do anyway.
+
+The persistent opener-bottom state ensures we never re-scan past a position that already failed to match. This is the same amortization that makes batch delimiter resolution O(n) — we're just spreading it across calls.
+
+### 10.7 Edge Cases
+
+**Newlines in new content**: A newline produces a Softbreak or Hardbreak token. This is a new node in the pool — O(1) to create. The 2-space-before-newline check for Hardbreak is O(1).
+
+**Code spans**: A backtick opener in chunk N might not find its closer until chunk N+100. The code span scanner needs to be made resumable — save the opener position and backtick count in state, scan forward on each new chunk. If the closer is found, replace all nodes between opener and closer with a single CodeSpan token.
+
+**Links**: `[text](url)` spans multiple tokens. The `[` creates a potential link opener. When `]` arrives, we look ahead for `(url)` or `[ref]`. If found, wrap the inner tokens. This is similar to delimiter resolution but with different pairing rules. The link scanner would need to be made resumable.
+
+**Link reference definitions**: These are extracted from paragraphs during assembly. In the incremental model, we'd need to check if the paragraph content so far is a link ref def prefix. This is a cold path — link ref defs are rare in LLM output.
+
+### 10.8 Implementation Complexity
+
+This is a moderate refactor:
+1. Move `NODE_POOL` from module-level to `StreamState` (per-stream isolation)
+2. Make `parseInlines` resumable — accept a start position and existing pool
+3. Make `resolveDelimiters` incremental — accept persistent opener-bottom state, process only new nodes
+4. Add code span and link resumability to state
+
+The batch path (`fullParse`) would be unaffected — it creates a fresh pool and runs to completion as today.
+
+Estimated effort: ~2-3 days for a correct implementation, ~1 week with thorough testing.
+
+### 10.9 Is It Worth It?
+
+For the LLM streaming use case: **probably not yet**. The text-append fast path handles ~70-80% of chunks (plain words). The paragraph continuation path handles the rest with O(N_para) inline re-parse, but N_para is typically < 1KB for LLM output. The inline re-parse for a 1KB paragraph takes ~10µs — imperceptible.
+
+The incremental inline architecture becomes valuable when:
+- Paragraphs are very long (> 10KB) — e.g., streaming a novel or long-form content
+- Chunks contain frequent special characters — e.g., code-heavy markdown with lots of backticks
+- Latency budget is extremely tight (< 1µs per chunk)
+
+### 10.9 Why Not Just Speculate More Aggressively?
+
+An alternative to incremental parsing: produce an *approximate* speculative token tree that's cheaper to compute. For example, emit unmatched `*` as literal text instead of running delimiter resolution, and only resolve when the paragraph ends.
+
+This doesn't work because the consumer needs the correct token tree to render. If `**bold**` is emitted as five Text tokens, the user sees literal asterisks. The visual difference is jarring — it's not "speculative rendering" but "wrong rendering". The consumer's contract with `stableCount` is that speculative tokens have the correct *structure* for the content seen so far, even though that structure might change when more content arrives.
+
+The right framing: speculative closure means "parse correctly with the content we have, knowing the result might change". It does NOT mean "parse approximately to save time". The incremental inline architecture achieves correct speculative closure with O(K) parsing work — no approximation needed.
+
+### 10.10 Summary: The Complete O(K) Picture
+
+With the incremental inline architecture, every streaming scenario achieves O(K) parsing work per chunk:
+
+| Scenario | Parsing cost | Output cost | Total |
+|----------|-------------|-------------|-------|
+| Plain text append | O(K) dispatch scan | O(1) extend Text | O(K) |
+| Fenced code / math | O(K) fence check | O(1) token construct | O(K) |
+| Paragraph, no delimiters | O(K) inline scan | O(K_nodes) append | O(K) |
+| Paragraph, new closer matches | O(K) scan + O(D_new) resolve | O(affected_range) re-compact | O(K + D_new) |
+| Block transition | O(K) line check | O(1) promote + new block | O(K) |
+| Container active (rare) | O(K) line check | O(inner) re-parse | O(inner) |
+
+The only non-O(K) case is container speculative closure, which is inherent to containers (inner block structure can change with each line) and rare in LLM streaming (~5% of chunks, briefly during transitions).
+
+For now, the fast-path approach provides the right trade-off: simple, correct, and fast enough for the primary use case. The incremental inline architecture is the path forward when the use case demands it.
+
+## 11. Other Future Work
+
+### 11.1 Conformance Test Harness
+
+Wire `packages/spec` against the CommonMark spec examples (652 tests) and GFM spec examples. Currently at 509 unit tests with 95.7% statement coverage, but no spec conformance tracking.
+
+### 11.2 HTML Renderer
+
+`packages/html` — convert token tree to HTML string. Separate package per the "parser outputs tokens only" constraint.
+
+### 11.3 Null Byte Replacement
+
+Spec §2.3 requires replacing U+0000 with U+FFFD. Not yet implemented — low priority as null bytes don't occur in LLM output.
+
+## 11. Known Limitations
+
+- **Bare CR before LF**: `abc\rX\ndef` — bare CR not detected as line ending when followed by LF on the same line. Spec §2.1 edge case.
+- **Blockquote lazy continuation**: Approximate — any non-blank, non-block-start line continues. Trade-off of flat architecture.
+- **Named HTML entities**: Emitted as raw text. Resolution is a renderer concern.
+- **Entity validation**: Accepts any `&name;` — no HTML5 entity list check.
+- **Thread safety**: Module-level shared state. Single-threaded use only.
+- **Forward reference resolution**: Link refs defined after their use don't resolve in earlier emissions.
+- **Paragraph inline re-parse**: O(N_para) when special characters present. Mitigated by text-append fast path for the common case. See §10 for the incremental inline architecture that would eliminate this.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "clean": "turbo run clean",
     "typecheck": "turbo run typecheck",
     "bench": "turbo run bench",
+    "bench:baseline": "npm run bench:baseline --workspace=@streamd/bench",
+    "bench:profile": "npm run bench:profile --workspace=@streamd/bench",
     "bench:browser": "turbo run bench:browser",
     "ci": "npm run lint && turbo run typecheck build test",
     "changeset": "changeset",

--- a/packages/bench/index.html
+++ b/packages/bench/index.html
@@ -15,12 +15,14 @@
   h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
   .subtitle { color: var(--text-muted); font-size: 0.875rem; margin-bottom: 0.5rem; }
   .controls { display: flex; gap: 0.75rem; align-items: center; margin-bottom: 1.5rem; flex-wrap: wrap; }
-  select, button { font-size: 0.875rem; padding: 0.5rem 1rem; border-radius: 6px; border: 1px solid var(--border); background: var(--surface); color: var(--text); cursor: pointer; }
+  select, input, button { font-size: 0.875rem; padding: 0.5rem 1rem; border-radius: 6px; border: 1px solid var(--border); background: var(--surface); color: var(--text); cursor: pointer; }
+  input[type=number] { width: 80px; cursor: text; }
   button { background: var(--accent); color: #000; font-weight: 600; border: none; }
   button:disabled { opacity: 0.5; cursor: not-allowed; }
   button:hover:not(:disabled) { filter: brightness(1.1); }
   .status { color: var(--text-muted); font-size: 0.8rem; }
-  .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
+  label { color: var(--text-muted); font-size: 0.8rem; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
   .card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem; position: relative; transition: border-color 0.2s; }
   .card.best { border-color: var(--green); }
   .card-name { font-weight: 600; font-size: 0.95rem; margin-bottom: 0.5rem; }
@@ -40,12 +42,13 @@
   .section-title { font-size: 1.1rem; font-weight: 600; margin: 1.5rem 0 0.75rem; }
   .progress { height: 4px; background: var(--border); border-radius: 2px; margin-bottom: 1rem; overflow: hidden; }
   .progress-bar { height: 100%; background: var(--accent); transition: width 0.3s; }
+  .mode-desc { color: var(--text-muted); font-size: 0.8rem; margin-bottom: 1rem; padding: 0.75rem; background: var(--surface); border-radius: 6px; border: 1px solid var(--border); }
 </style>
 </head>
 <body>
 
 <h1>@streamd/parser Benchmark</h1>
-<p class="subtitle">Compare parsing throughput across markdown parsers — runs entirely in your browser.</p>
+<p class="subtitle">Compare parsing performance across markdown parsers — runs entirely in your browser.</p>
 <p class="subtitle" id="precisionNote" style="color: var(--yellow)"></p>
 
 <div class="controls">
@@ -57,9 +60,17 @@
     <option value="pathological-star">Pathological *×10000</option>
     <option value="pathological-bq">Pathological >×200</option>
   </select>
+  <select id="modeSelect">
+    <option value="static" selected>Static Parse</option>
+    <option value="streaming">Streaming</option>
+  </select>
+  <label>Chunk size: <input type="number" id="chunkSize" value="200" min="1" max="10000"></label>
+  <label>Iterations: <input type="number" id="iterations" value="" min="0" max="100000" placeholder="auto"></label>
   <button id="runBtn" type="button">Run Benchmark</button>
   <span id="status" class="status">Ready</span>
 </div>
+
+<div id="modeDesc" class="mode-desc" style="display:none"></div>
 
 <div class="progress" id="progressWrap" style="display:none">
   <div class="progress-bar" id="progressBar" style="width:0%"></div>
@@ -69,7 +80,7 @@
 
 <h3 class="section-title" id="tableTitle" style="display:none">Detailed Results</h3>
 <table id="resultsTable" style="display:none">
-  <thead><tr><th>Parser</th><th>Median</th><th>p95</th><th>Ops/s</th><th>Throughput</th></tr></thead>
+  <thead id="resultsHead"></thead>
   <tbody id="resultsBody"></tbody>
 </table>
 
@@ -79,19 +90,24 @@ import { CommonmarkParser, MarkdownIt, marked, streamdParse } from './dist/brows
 const mdIt = new MarkdownIt();
 const cmParser = new CommonmarkParser();
 
-// --- Timer precision detection ---
+// --- Timer precision ---
 const isHighRes = typeof crossOriginIsolated !== 'undefined' && crossOriginIsolated;
 const precisionNote = document.getElementById('precisionNote');
 if (isHighRes) {
   precisionNote.textContent = '\u2713 High precision timers (cross-origin isolated).';
   precisionNote.style.color = 'var(--green)';
 } else {
-  precisionNote.textContent = '\u26A0 Low precision timers (100\u00B5s). Run: cd packages/bench && bun run bench:browser';
+  precisionNote.textContent = '\u26A0 Low precision timers (100\u00B5s). Serve with COOP/COEP headers for full precision.';
 }
 
-// --- Yield to event loop so UI updates between parsers ---
 function nextFrame() {
   return new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)));
+}
+
+function fmtTime(ms) {
+  if (ms < 0.001) return (ms * 1000000).toFixed(0) + ' ns';
+  if (ms < 1) return (ms * 1000).toFixed(0) + ' \u00B5s';
+  return ms.toFixed(2) + ' ms';
 }
 
 // --- Input generators ---
@@ -113,62 +129,7 @@ function generateMixed(sizeKb) {
   return parts.join("").slice(0, sizeKb * 1024);
 }
 
-const SAMPLE_MD = `# Building Modern React Applications
-
-**Published:** December 9, 2025 | **Reading Time:** 8 minutes
-
----
-
-## Introduction
-
-React has evolved significantly, and 2025 brings exciting new patterns and best practices for building scalable applications. In this guide, we'll explore the latest trends that **every React developer** should know.
-
-For more information, visit the official [React documentation](https://react.dev).
-
-### Key Topics
-
-1. **Server Components** - The future of React
-2. **Performance Optimization** - Making your apps blazing fast
-3. **State Management** - Modern approaches
-
----
-
-## Server Components: A Game Changer
-
-| Approach | Bundle Size | Load Time |
-|----------|------------|-----------|
-| Traditional SPA | **250 KB** | 2.5s |
-| SSR | **180 KB** | 1.8s |
-| RSC | **120 KB** | 1.2s |
-
-> "Server Components are a fundamental shift in how we architect React applications."
->
-> \u2014 [Dan Abramov](https://twitter.com/dan_abramov)
-
-### Code Splitting
-
-\\\`\\\`\\\`typescript
-import { lazy, Suspense } from "react";
-const Dashboard = lazy(() => import("./Dashboard"));
-\\\`\\\`\\\`
-
-### Memoization
-
-- Use \\\`useMemo\\\` for expensive calculations
-- Use \\\`useCallback\\\` for function references
-- ~~Don't~~ use them for simple values
-
-## Features Checklist
-
-- [x] Server-side data fetching
-- [x] Optimistic UI updates
-- [ ] Advanced filtering
-- [ ] Export functionality
-
----
-
-*Last updated: December 9, 2025*
-`;
+const SAMPLE_MD = `# Building Modern React Applications\n\n**Published:** December 9, 2025 | **Reading Time:** 8 minutes\n\n---\n\n## Introduction\n\nReact has evolved significantly. In this guide, we explore the latest trends that **every React developer** should know.\n\nFor more information, visit the official [React documentation](https://react.dev).\n\n### Key Topics\n\n1. **Server Components** - The future of React\n2. **Performance Optimization** - Making your apps blazing fast\n3. **State Management** - Modern approaches\n\n---\n\n## Server Components\n\n| Approach | Bundle Size | Load Time |\n|----------|------------|----------|\n| Traditional SPA | **250 KB** | 2.5s |\n| SSR | **180 KB** | 1.8s |\n| RSC | **120 KB** | 1.2s |\n\n> "Server Components are a fundamental shift in how we architect React applications."\n\n\`\`\`typescript\nimport { lazy, Suspense } from "react";\nconst Dashboard = lazy(() => import("./Dashboard"));\n\`\`\`\n\n- Use \`useMemo\` for expensive calculations\n- Use \`useCallback\` for function references\n- ~~Don't~~ use them for simple values\n\n## Features Checklist\n\n- [x] Server-side data fetching\n- [x] Optimistic UI updates\n- [ ] Advanced filtering\n- [ ] Export functionality\n\n---\n\n*Last updated: December 9, 2025*\n`;
 
 const INPUTS = {
   'synthetic-1': () => generateMixed(1),
@@ -179,18 +140,17 @@ const INPUTS = {
   'pathological-bq': () => '> '.repeat(200) + 'text',
 };
 
-// --- Parsers ---
+// --- All parsers ---
 const PARSERS = [
-  { name: '@streamd/parser', fn: (s) => streamdParse(s) },
-  { name: 'marked', fn: (s) => marked.lexer(s) },
-  { name: 'markdown-it', fn: (s) => mdIt.parse(s, {}) },
-  { name: 'commonmark.js', fn: (s) => cmParser.parse(s) },
+  { name: '@streamd/parser', fn: (s) => streamdParse(s), color: 'var(--accent)' },
+  { name: 'marked', fn: (s) => marked.lexer(s), color: '#f97316' },
+  { name: 'markdown-it', fn: (s) => mdIt.parse(s, {}), color: '#a855f7' },
+  { name: 'commonmark.js', fn: (s) => cmParser.parse(s), color: '#ec4899' },
 ];
 
-// --- Benchmark runner ---
-// Runs warmup, then measures in batches, yielding between batches
-// so the UI stays responsive even on large inputs.
-function runSync(fn, src, iterations) {
+// --- Static benchmark ---
+function runStatic(fn, src, warmup, iterations) {
+  for (let i = 0; i < warmup; i++) fn(src);
   const times = new Float64Array(iterations);
   for (let i = 0; i < iterations; i++) {
     const t0 = performance.now();
@@ -205,12 +165,77 @@ function computeStats(name, times, srcLen) {
   const len = sorted.length;
   const median = sorted[Math.floor(len / 2)] || 0.001;
   const p95 = sorted[Math.floor(len * 0.95)] || 0.001;
-  const min = sorted[0] || 0.001;
-  const max = sorted[len - 1] || 0.001;
-  const avg = sorted.reduce((a, b) => a + b, 0) / len;
   const opsPerSec = median > 0.0001 ? 1000 / median : 999999;
   const throughput = median > 0.0001 ? (srcLen / 1048576) / (median / 1000) : 999999;
-  return { name, median, p95, min, max, avg, opsPerSec, throughput };
+  return { name, median, p95, opsPerSec, throughput };
+}
+
+// --- Streaming benchmark (fair: same accumulated string for all parsers) ---
+function benchStreamingFair(name, parseFn, src, chunkSize, warmup, iterations) {
+  const boundaries = [];
+  for (let i = chunkSize; i < src.length; i += chunkSize) boundaries.push(i);
+  boundaries.push(src.length);
+  const numChunks = boundaries.length;
+
+  // Warmup
+  for (let w = 0; w < warmup; w++) {
+    let state = null;
+    for (let c = 0; c < numChunks; c++) {
+      state = parseFn(src.slice(0, boundaries[c]), state);
+    }
+  }
+
+  // Measure
+  const chunkTimes = [];
+  const totalTimes = [];
+  for (let iter = 0; iter < iterations; iter++) {
+    const totalStart = performance.now();
+    let state = null;
+    for (let c = 0; c < numChunks; c++) {
+      const accumulated = src.slice(0, boundaries[c]);
+      const t0 = performance.now();
+      state = parseFn(accumulated, state);
+      chunkTimes.push(performance.now() - t0);
+    }
+    totalTimes.push(performance.now() - totalStart);
+  }
+
+  chunkTimes.sort((a, b) => a - b);
+  totalTimes.sort((a, b) => a - b);
+  const totalMs = totalTimes[Math.floor(totalTimes.length / 2)] || 0.001;
+  const perChunkMedian = chunkTimes[Math.floor(chunkTimes.length / 2)] || 0.0001;
+  const throughput = totalMs > 0.0001 ? (src.length / 1048576) / (totalMs / 1000) : 999999;
+  return { name, numChunks, totalMs, perChunkMedian, throughput };
+}
+
+// --- UI rendering ---
+function renderCards(results, metric) {
+  const el = document.getElementById('cards');
+  const values = results.map(r => r[metric]);
+  const fastest = Math.max(...values);
+  const slowest = Math.min(...values);
+
+  el.innerHTML = results.map(r => {
+    const isBest = r[metric] === fastest;
+    const ratio = slowest > 0.001 ? (r[metric] / slowest).toFixed(1) : '\u2014';
+    return `<div class="card ${isBest ? 'best' : ''}">
+      ${isBest ? '<span class="badge">FASTEST</span>' : ''}
+      <div class="card-name">${r.name}</div>
+      <div class="card-hero">${ratio}<span class="card-hero-unit">\u00D7</span></div>
+      <div class="stats">${r.stats.map(s =>
+        `<div class="stat"><span class="stat-label">${s[0]}</span><span class="stat-value">${s[1]}</span></div>`
+      ).join('')}</div>
+    </div>`;
+  }).join('');
+}
+
+function renderTable(headers, rows) {
+  document.getElementById('resultsHead').innerHTML = '<tr>' + headers.map(h => `<th>${h}</th>`).join('') + '</tr>';
+  document.getElementById('resultsBody').innerHTML = rows.map(r =>
+    '<tr>' + r.map(c => `<td>${c}</td>`).join('') + '</tr>'
+  ).join('');
+  document.getElementById('resultsTable').style.display = '';
+  document.getElementById('tableTitle').style.display = '';
 }
 
 function chooseIterations(srcLen) {
@@ -219,52 +244,98 @@ function chooseIterations(srcLen) {
   return { warmup: 100, iterations: 1000 };
 }
 
-// --- UI rendering ---
-function renderCards(results) {
-  const el = document.getElementById('cards');
-  const fastest = Math.max(...results.map(r => r.throughput));
-  const slowest = Math.min(...results.map(r => r.throughput));
-
-  el.innerHTML = results.map(r => {
-    const isBest = r.throughput === fastest;
-    const ratio = slowest > 0.001 ? (r.throughput / slowest).toFixed(1) : '\u2014';
-    return `<div class="card ${isBest ? 'best' : ''}">
-      ${isBest ? '<span class="badge">FASTEST</span>' : ''}
-      <div class="card-name">${r.name}</div>
-      <div class="card-hero">${ratio}<span class="card-hero-unit">\u00D7 faster</span></div>
-      <div class="stats">
-        <div class="stat"><span class="stat-label">Throughput</span><span class="stat-value">${r.throughput.toFixed(1)} MB/s</span></div>
-        <div class="stat"><span class="stat-label">Ops/s</span><span class="stat-value">${r.opsPerSec.toFixed(0)}</span></div>
-        <div class="stat"><span class="stat-label">Median</span><span class="stat-value">${fmtTime(r.median)}</span></div>
-        <div class="stat"><span class="stat-label">p95</span><span class="stat-value">${fmtTime(r.p95)}</span></div>
-        <div class="stat"><span class="stat-label">Min</span><span class="stat-value">${fmtTime(r.min)}</span></div>
-        <div class="stat"><span class="stat-label">Max</span><span class="stat-value">${fmtTime(r.max)}</span></div>
-      </div>
-    </div>`;
-  }).join('');
-}
-
-function renderTable(results) {
-  const tbody = document.getElementById('resultsBody');
-  tbody.innerHTML = results.map(r => `<tr>
-    <td>${r.name}</td>
-    <td>${fmtTime(r.median)}</td>
-    <td>${fmtTime(r.p95)}</td>
-    <td>${r.opsPerSec.toFixed(0)}</td>
-    <td>${r.throughput.toFixed(1)} MB/s</td>
-  </tr>`).join('');
-  document.getElementById('resultsTable').style.display = '';
-  document.getElementById('tableTitle').style.display = '';
-}
-
-function fmtTime(ms) {
-  if (ms < 0.001) return `${(ms * 1000000).toFixed(0)} ns`;
-  if (ms < 1) return `${(ms * 1000).toFixed(0)} \u00B5s`;
-  return `${ms.toFixed(2)} ms`;
-}
-
-// --- Main benchmark loop ---
+// --- Main ---
 let running = false;
+
+async function runStreamingBench(src, sizeKb, chunkSize, status, progressBar, modeDesc) {
+  modeDesc.style.display = '';
+  modeDesc.innerHTML = `<strong>Streaming simulation</strong>: ${sizeKb} KB input, ${chunkSize}B chunks (${Math.ceil(src.length / chunkSize)} chunks total).<br>` +
+    `All parsers receive the same accumulated source string on each chunk.<br>` +
+    `<strong>@streamd/parser</strong> uses incremental state \u2014 others re-parse from scratch.`;
+
+  const userIter = parseInt(document.getElementById('iterations').value, 10) || 0;
+  const iterations = userIter > 0 ? userIter : (src.length > 100000 ? 10 : 30);
+  const warmup = Math.max(3, Math.floor(iterations / 5));
+  const total = PARSERS.length;
+  const results = [];
+
+  for (let i = 0; i < total; i++) {
+    const p = PARSERS[i];
+    status.textContent = `Benchmarking ${p.name}... (${i + 1}/${total})`;
+    progressBar.style.width = `${((i + 0.5) / total) * 100}%`;
+    await nextFrame();
+
+    const parseFn = p.name === '@streamd/parser'
+      ? (acc, state) => streamdParse(acc, state).state
+      : (acc) => { p.fn(acc); return null; };
+
+    const r = benchStreamingFair(p.name, parseFn, src, chunkSize, warmup, iterations);
+    results.push({
+      ...r,
+      stats: [
+        ['Throughput', r.throughput.toFixed(1) + ' MB/s'],
+        ['Total', fmtTime(r.totalMs)],
+        ['Per chunk', fmtTime(r.perChunkMedian)],
+        ['Chunks', String(r.numChunks)],
+      ],
+    });
+    progressBar.style.width = `${((i + 1) / total) * 100}%`;
+    await nextFrame();
+  }
+
+  renderCards(results, 'throughput');
+  renderTable(
+    ['Parser', 'Chunks', 'Total', 'Per chunk (median)', 'Throughput'],
+    results.map(r => [r.name, r.numChunks, fmtTime(r.totalMs), fmtTime(r.perChunkMedian), r.throughput.toFixed(1) + ' MB/s']),
+  );
+  return `Done \u2014 streaming ${sizeKb} KB in ${chunkSize}B chunks.`;
+}
+
+async function runStaticBench(src, sizeKb, status, progressBar, modeDesc) {
+  modeDesc.style.display = '';
+  modeDesc.innerHTML = `<strong>Static parse</strong>: ${sizeKb} KB input. Each parser parses the full document once per iteration.`;
+
+  const userIter = parseInt(document.getElementById('iterations').value, 10) || 0;
+  const auto = chooseIterations(src.length);
+  const warmup = userIter > 0 ? Math.max(10, Math.floor(userIter / 5)) : auto.warmup;
+  const iterations = userIter > 0 ? userIter : auto.iterations;
+  const total = PARSERS.length;
+  const results = [];
+
+  for (let i = 0; i < total; i++) {
+    const p = PARSERS[i];
+    status.textContent = `Warming up ${p.name}... (${i + 1}/${total})`;
+    progressBar.style.width = `${((i + 0.3) / total) * 100}%`;
+    await nextFrame();
+
+    runStatic(p.fn, src, warmup, 0);
+
+    status.textContent = `Measuring ${p.name}... (${i + 1}/${total})`;
+    progressBar.style.width = `${((i + 0.7) / total) * 100}%`;
+    await nextFrame();
+
+    const times = runStatic(p.fn, src, 0, iterations);
+    const s = computeStats(p.name, times, src.length);
+    results.push({
+      ...s,
+      stats: [
+        ['Throughput', s.throughput.toFixed(1) + ' MB/s'],
+        ['Ops/s', s.opsPerSec.toFixed(0)],
+        ['Median', fmtTime(s.median)],
+        ['p95', fmtTime(s.p95)],
+      ],
+    });
+    progressBar.style.width = `${((i + 1) / total) * 100}%`;
+    await nextFrame();
+  }
+
+  renderCards(results, 'throughput');
+  renderTable(
+    ['Parser', 'Median', 'p95', 'Ops/s', 'Throughput'],
+    results.map(r => [r.name, fmtTime(r.median), fmtTime(r.p95), r.opsPerSec.toFixed(0), r.throughput.toFixed(1) + ' MB/s']),
+  );
+  return `Done \u2014 ${iterations}\u00D7 iterations on ${sizeKb} KB input.`;
+}
 
 document.getElementById('runBtn').addEventListener('click', async () => {
   if (running) return;
@@ -272,56 +343,41 @@ document.getElementById('runBtn').addEventListener('click', async () => {
 
   const btn = document.getElementById('runBtn');
   const status = document.getElementById('status');
+  const modeDesc = document.getElementById('modeDesc');
   const progressWrap = document.getElementById('progressWrap');
   const progressBar = document.getElementById('progressBar');
+  const mode = document.getElementById('modeSelect').value;
+  const chunkSize = parseInt(document.getElementById('chunkSize').value, 10) || 200;
 
   btn.disabled = true;
   progressWrap.style.display = '';
   progressBar.style.width = '0%';
+  document.getElementById('cards').innerHTML = '';
+  document.getElementById('resultsTable').style.display = 'none';
+  document.getElementById('tableTitle').style.display = 'none';
 
   const inputKey = document.getElementById('inputSelect').value;
   const src = INPUTS[inputKey]();
   const sizeKb = (src.length / 1024).toFixed(1);
-  const { warmup, iterations } = chooseIterations(src.length);
 
-  status.textContent = `Input: ${sizeKb} KB \u2022 ${warmup} warmup + ${iterations} iterations`;
-  await nextFrame();
-
-  const results = [];
-
-  for (let i = 0; i < PARSERS.length; i++) {
-    const p = PARSERS[i];
-
-    // Update UI before each parser
-    status.textContent = `Warming up ${p.name}... (${i + 1}/${PARSERS.length})`;
-    progressBar.style.width = `${((i + 0.3) / PARSERS.length) * 100}%`;
-    await nextFrame();
-
-    // Warmup — separate from measurement, lets JIT stabilize
-    runSync(p.fn, src, warmup);
-
-    // Yield after warmup so UI can paint
-    status.textContent = `Measuring ${p.name}... (${i + 1}/${PARSERS.length})`;
-    progressBar.style.width = `${((i + 0.7) / PARSERS.length) * 100}%`;
-    await nextFrame();
-
-    // Measurement
-    const times = runSync(p.fn, src, iterations);
-    results.push(computeStats(p.name, times, src.length));
-
-    // Yield after measurement
-    progressBar.style.width = `${((i + 1) / PARSERS.length) * 100}%`;
-    await nextFrame();
+  if (mode === 'streaming') {
+    status.textContent = await runStreamingBench(src, sizeKb, chunkSize, status, progressBar, modeDesc);
+  } else {
+    status.textContent = await runStaticBench(src, sizeKb, status, progressBar, modeDesc);
   }
 
-  renderCards(results);
-  renderTable(results);
-
-  status.textContent = `Done \u2014 ${iterations}\u00D7 iterations on ${sizeKb} KB input.`;
   btn.disabled = false;
   progressWrap.style.display = 'none';
   running = false;
 });
+
+// Show/hide chunk size based on mode
+document.getElementById('modeSelect').addEventListener('change', (e) => {
+  document.getElementById('chunkSize').parentElement.style.display =
+    e.target.value === 'streaming' ? '' : 'none';
+});
+// Initial state
+document.getElementById('chunkSize').parentElement.style.display = 'none';
 </script>
 
 </body>

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -5,7 +5,9 @@
   "description": "Performance benchmarks for @streamd/parser",
   "type": "module",
   "scripts": {
-    "bench": "tsx src/index.ts",
+    "bench": "turbo run build --filter=@streamd/parser && tsx src/index.ts",
+    "bench:baseline": "turbo run build --filter=@streamd/parser && tsx src/baseline.ts",
+    "bench:profile": "turbo run build --filter=@streamd/parser && tsx src/profile-streaming.ts",
     "build": "tsdown",
     "bench:browser": "tsdown && node serve.js",
     "serve": "node serve.js"

--- a/packages/bench/src/baseline.ts
+++ b/packages/bench/src/baseline.ts
@@ -1,0 +1,179 @@
+/**
+ * Baseline benchmark — captures static and streaming performance.
+ *
+ * Run before and after changes to verify zero static regression
+ * and measure streaming improvements.
+ *
+ * Usage: npx tsx packages/bench/src/baseline.ts
+ *
+ * @module bench/baseline
+ */
+import { parse as streamdParse } from "@streamd/parser";
+import { generateCode, generateMixed, generateParagraphs } from "./generate";
+import { bench, benchStreaming } from "./runner";
+
+function printTable(rows: Array<Array<string>>): void {
+  if (rows.length === 0) return;
+  const cols = rows[0]!.length;
+  const widths: Array<number> = [];
+  for (let c = 0; c < cols; c++) {
+    let max = 0;
+    for (const row of rows) {
+      if (row[c]!.length > max) max = row[c]!.length;
+    }
+    widths.push(max);
+  }
+  for (let r = 0; r < rows.length; r++) {
+    const cells = rows[r]!.map((cell, c) =>
+      c === 0 ? cell.padEnd(widths[c]!) : cell.padStart(widths[c]!),
+    );
+    console.log(`| ${cells.join(" | ")} |`);
+    if (r === 0) console.log(`|${widths.map((w) => "-".repeat(w + 2)).join("|")}|`);
+  }
+}
+
+function fmtMs(ms: number): string {
+  if (ms < 0.001) return (ms * 1_000_000).toFixed(0) + " ns";
+  if (ms < 1) return (ms * 1000).toFixed(1) + " \u00B5s";
+  return ms.toFixed(3) + " ms";
+}
+
+// ── Static parse ──────────────────────────────────────────────
+
+console.log("=== Static Parse (@streamd/parser only) ===\n");
+
+const staticInputs = [
+  { label: "Mixed 1 KB", src: generateMixed(1), warmup: 500, iter: 5000 },
+  { label: "Mixed 10 KB", src: generateMixed(10), warmup: 200, iter: 2000 },
+  { label: "Mixed 50 KB", src: generateMixed(50), warmup: 100, iter: 500 },
+  { label: "Mixed 500 KB", src: generateMixed(500), warmup: 20, iter: 100 },
+  { label: "Paragraphs 50 KB", src: generateParagraphs(50), warmup: 100, iter: 500 },
+  { label: "Code blocks 50 KB", src: generateCode(50), warmup: 100, iter: 500 },
+  { label: "Pathological * x10000", src: "*".repeat(10000), warmup: 200, iter: 2000 },
+  { label: "Pathological > x200", src: "> ".repeat(200) + "text", warmup: 200, iter: 2000 },
+];
+
+const staticRows: Array<Array<string>> = [["Input", "Median", "p95", "Throughput"]];
+for (const { label, src, warmup, iter } of staticInputs) {
+  const r = bench(label, (s) => streamdParse(s), src, warmup, iter);
+  staticRows.push([label, fmtMs(r.median), fmtMs(r.p95), r.throughput.toFixed(1) + " MB/s"]);
+}
+printTable(staticRows);
+
+// ── Streaming: fast-path breakdown ────────────────────────────
+
+console.log("\n=== Streaming Fast-Path Breakdown (50 KB mixed) ===\n");
+console.log("Each row simulates LLM streaming at different chunk sizes.\n");
+
+const streamSrc = generateMixed(50);
+const streamHeader = ["Scenario", "Chunks", "Total", "Per chunk (median)", "Throughput"];
+const streamRows: Array<Array<string>> = [streamHeader];
+
+for (const cs of [3, 10, 50, 200, 1000]) {
+  const r = benchStreaming(
+    `${cs}B chunks`,
+    (acc: string, state?: unknown) => streamdParse(acc, state as null),
+    streamSrc,
+    cs,
+    20,
+    50,
+  );
+  streamRows.push([
+    `Mixed ${cs}B chunks`,
+    String(r.numChunks),
+    fmtMs(r.totalMs),
+    fmtMs(r.perChunkMedianMs),
+    r.throughput.toFixed(1) + " MB/s",
+  ]);
+}
+
+// Full parse baseline for comparison
+const fullR = bench("full", (s) => streamdParse(s), streamSrc, 100, 500);
+streamRows.push([
+  "Full parse (no streaming)",
+  "1",
+  fmtMs(fullR.median),
+  "\u2014",
+  fullR.throughput.toFixed(1) + " MB/s",
+]);
+
+printTable(streamRows);
+
+// ── Streaming: content-type breakdown ─────────────────────────
+
+console.log("\n=== Streaming by Content Type (10 KB, 50B chunks) ===\n");
+console.log("Tests which fast paths fire for different content.\n");
+
+const contentTypes = [
+  {
+    label: "Plain text (no special chars)",
+    src: "The quick brown fox jumps over the lazy dog and keeps running. ".repeat(170),
+  },
+  { label: "Paragraphs with **bold**", src: generateParagraphs(10) },
+  { label: "Fenced code blocks", src: generateCode(10) },
+  { label: "Mixed markdown", src: generateMixed(10) },
+  { label: "Heavy inline: *a* **b** `c` [d](e)", src: "*a* **b** `c` [d](e) ~f~ ".repeat(400) },
+];
+
+const contentHeader = ["Content Type", "Chunks", "Total", "Per chunk (median)", "Throughput"];
+const contentRows: Array<Array<string>> = [contentHeader];
+
+for (const { label, src } of contentTypes) {
+  const r = benchStreaming(
+    label,
+    (acc: string, state?: unknown) => streamdParse(acc, state as null),
+    src,
+    50,
+    20,
+    50,
+  );
+  contentRows.push([
+    label,
+    String(r.numChunks),
+    fmtMs(r.totalMs),
+    fmtMs(r.perChunkMedianMs),
+    r.throughput.toFixed(1) + " MB/s",
+  ]);
+}
+
+printTable(contentRows);
+
+// ── Streaming: paragraph scaling ──────────────────────────────
+
+console.log("\n=== Paragraph Scaling (single paragraph, 50B chunks) ===\n");
+console.log("Shows O(N_para) inline re-parse cost as paragraph grows.\n");
+
+const paraScaleHeader = ["Paragraph Size", "Chunks", "Total", "Per chunk (median)", "vs 1KB"];
+const paraScaleRows: Array<Array<string>> = [paraScaleHeader];
+let baselinePerChunk = 0;
+
+for (const sizeKb of [1, 5, 10, 25, 50]) {
+  // Single long paragraph with occasional bold markers
+  const para = "Hello world this is text with **bold** and *italic* markers. "
+    .repeat(Math.ceil((sizeKb * 1024) / 60))
+    .slice(0, sizeKb * 1024);
+  const r = benchStreaming(
+    `${sizeKb}KB`,
+    (acc: string, state?: unknown) => streamdParse(acc, state as null),
+    para,
+    50,
+    10,
+    30,
+  );
+  if (sizeKb === 1) baselinePerChunk = r.perChunkMedianMs;
+  const ratio =
+    baselinePerChunk > 0 ? (r.perChunkMedianMs / baselinePerChunk).toFixed(1) + "x" : "1.0x";
+  paraScaleRows.push([
+    `${sizeKb} KB paragraph`,
+    String(r.numChunks),
+    fmtMs(r.totalMs),
+    fmtMs(r.perChunkMedianMs),
+    ratio,
+  ]);
+}
+
+printTable(paraScaleRows);
+console.log(
+  "\nIf per-chunk time scales linearly with paragraph size, inline re-parse is the bottleneck.",
+);
+console.log("If it stays flat, fast paths are handling it.\n");

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -2,7 +2,11 @@
  * Unified benchmark suite for @streamd/parser.
  *
  * Compares @streamd/parser against marked, markdown-it, and commonmark.js
- * across synthetic and real-world inputs.
+ * across static and streaming workloads.
+ *
+ * Streaming benchmark: all parsers receive the same accumulated source string
+ * on each chunk. @streamd uses incremental state; others re-parse from scratch.
+ * This is the fair comparison — same input, different strategies.
  *
  * Usage: npx tsx packages/bench/src/index.ts
  *
@@ -13,15 +17,11 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as streamdParse } from "@streamd/parser";
 import { generateMixed } from "./generate";
-import { type BenchResult, bench } from "./runner";
+import { bench } from "./runner";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const sampleMd = readFileSync(resolve(__dirname, "../fixtures/sample.md"), "utf8");
 
-/** All parsers under test. */
-const parsers = [{ name: "@streamd/parser", fn: (s: string) => streamdParse(s) }];
-
-/** All inputs to benchmark. */
 const inputs = [
   { label: "Synthetic 1 KB", src: generateMixed(1), warmup: 200, iter: 2000 },
   { label: "Synthetic 50 KB", src: generateMixed(50), warmup: 100, iter: 500 },
@@ -37,6 +37,7 @@ const inputs = [
 ];
 
 function printTable(rows: Array<Array<string>>): void {
+  if (rows.length === 0) return;
   const cols = rows[0]!.length;
   const widths: Array<number> = [];
   for (let c = 0; c < cols; c++) {
@@ -46,66 +47,203 @@ function printTable(rows: Array<Array<string>>): void {
     }
     widths.push(max);
   }
-
   for (let r = 0; r < rows.length; r++) {
     const cells = rows[r]!.map((cell, c) =>
       c === 0 ? cell.padEnd(widths[c]!) : cell.padStart(widths[c]!),
     );
     console.log(`| ${cells.join(" | ")} |`);
-    if (r === 0) {
-      console.log(`|${widths.map((w) => "-".repeat(w + 2)).join("|")}|`);
+    if (r === 0) console.log(`|${widths.map((w) => "-".repeat(w + 2)).join("|")}|`);
+  }
+}
+
+function fmtMs(ms: number): string {
+  if (ms < 0.001) return (ms * 1_000_000).toFixed(0) + " ns";
+  if (ms < 1) return (ms * 1000).toFixed(1) + " \u00B5s";
+  return ms.toFixed(3) + " ms";
+}
+
+/** Result of a streaming benchmark. */
+interface StreamResult {
+  name: string;
+  numChunks: number;
+  totalMedianMs: number;
+  perChunkMedianMs: number;
+  throughput: number;
+}
+
+/**
+ * Benchmark streaming parse — all parsers receive the same accumulated string.
+ *
+ * Simulates LLM streaming: source arrives in chunks of `chunkSize` bytes.
+ * On each chunk, the parser receives the full accumulated source so far.
+ * @streamd uses state for incremental parsing; others re-parse from scratch.
+ */
+function benchStreamingFair(
+  name: string,
+  parseFn: (accumulated: string, state: unknown) => unknown,
+  src: string,
+  chunkSize: number,
+  warmup: number,
+  iterations: number,
+): StreamResult {
+  // Pre-compute chunk boundaries
+  const boundaries: Array<number> = [];
+  for (let i = chunkSize; i < src.length; i += chunkSize) boundaries.push(i);
+  boundaries.push(src.length);
+  const numChunks = boundaries.length;
+
+  // Warmup
+  for (let w = 0; w < warmup; w++) {
+    let state: unknown = null;
+    for (let c = 0; c < numChunks; c++) {
+      state = parseFn(src.slice(0, boundaries[c]!), state);
     }
   }
+
+  // Measure
+  const chunkTimes: Array<number> = [];
+  const totalTimes: Array<number> = [];
+
+  for (let iter = 0; iter < iterations; iter++) {
+    const totalStart = performance.now();
+    let state: unknown = null;
+    for (let c = 0; c < numChunks; c++) {
+      const accumulated = src.slice(0, boundaries[c]!);
+      const t0 = performance.now();
+      state = parseFn(accumulated, state);
+      chunkTimes.push(performance.now() - t0);
+    }
+    totalTimes.push(performance.now() - totalStart);
+  }
+
+  chunkTimes.sort((a, b) => a - b);
+  totalTimes.sort((a, b) => a - b);
+
+  const totalMedianMs = totalTimes[Math.floor(totalTimes.length / 2)]!;
+  const perChunkMedianMs = chunkTimes[Math.floor(chunkTimes.length / 2)]!;
+  const throughput = src.length / 1024 / 1024 / (totalMedianMs / 1000);
+
+  return { name, numChunks, totalMedianMs, perChunkMedianMs, throughput };
 }
 
 async function main(): Promise<void> {
   const { marked } = await import("marked");
   const MarkdownIt = (await import("markdown-it")).default;
   const { Parser: CmParser } = await import("commonmark");
-
   const md = new MarkdownIt();
   const cmParser = new CmParser();
 
   const allParsers = [
-    ...parsers,
+    { name: "@streamd/parser", fn: (s: string) => streamdParse(s) },
     { name: "marked", fn: (s: string) => marked.lexer(s) },
     { name: "markdown-it", fn: (s: string) => md.parse(s, {}) },
     { name: "commonmark.js", fn: (s: string) => cmParser.parse(s) },
   ];
 
-  console.log("@streamd/parser benchmark suite\n");
+  // === Static parse ===
+  console.log("=== Static Parse ===\n");
 
-  const header = ["Input", ...allParsers.map((p) => p.name)];
-  const rows: Array<Array<string>> = [header];
-
-  for (const { label, src, warmup, iter } of inputs) {
-    const results: Array<BenchResult> = [];
-    for (const parser of allParsers) {
-      results.push(bench(parser.name, parser.fn, src, warmup, iter));
-    }
-
-    const row = [
-      `${label} (${(src.length / 1024).toFixed(1)} KB)`,
-      ...results.map((r) => `${r.throughput.toFixed(1)} MB/s`),
-    ];
-    rows.push(row);
-  }
-
-  printTable(rows);
-
-  console.log("\n--- Detailed latency ---\n");
-
-  const latencyHeader = ["Input", "Parser", "Median", "p95"];
-  const latencyRows: Array<Array<string>> = [latencyHeader];
+  const staticHeader = ["Input", ...allParsers.map((p) => p.name)];
+  const staticRows: Array<Array<string>> = [staticHeader];
 
   for (const { label, src, warmup, iter } of inputs) {
+    const cells = [label];
     for (const parser of allParsers) {
       const r = bench(parser.name, parser.fn, src, warmup, iter);
-      latencyRows.push([label, parser.name, `${r.median.toFixed(3)}ms`, `${r.p95.toFixed(3)}ms`]);
+      cells.push(fmtMs(r.median) + " / " + r.throughput.toFixed(0) + " MB/s");
     }
+    staticRows.push(cells);
   }
 
-  printTable(latencyRows);
+  printTable(staticRows);
+
+  // === Streaming ===
+  console.log("\n=== Streaming Simulation (50 KB, 200B chunks) ===\n");
+  console.log("All parsers receive the same accumulated source string on each chunk.");
+  console.log("@streamd uses incremental state; others re-parse from scratch.\n");
+
+  const streamSrc = generateMixed(50);
+
+  // Define streaming parsers — all receive (accumulated, state) → state
+  const streamParsers = [
+    {
+      name: "@streamd/parser",
+      fn: (acc: string, state: unknown) => streamdParse(acc, state as null).state,
+    },
+    {
+      name: "marked",
+      fn: (acc: string, _state: unknown) => {
+        marked.lexer(acc);
+        return null;
+      },
+    },
+    {
+      name: "markdown-it",
+      fn: (acc: string, _state: unknown) => {
+        md.parse(acc, {});
+        return null;
+      },
+    },
+    {
+      name: "commonmark.js",
+      fn: (acc: string, _state: unknown) => {
+        cmParser.parse(acc);
+        return null;
+      },
+    },
+  ];
+
+  const streamHeader = ["Parser", "Chunks", "Total", "Per chunk (median)", "Throughput"];
+  const streamRows: Array<Array<string>> = [streamHeader];
+
+  for (const p of streamParsers) {
+    const r = benchStreamingFair(p.name, p.fn, streamSrc, 200, 10, 30);
+    streamRows.push([
+      p.name,
+      String(r.numChunks),
+      fmtMs(r.totalMedianMs),
+      fmtMs(r.perChunkMedianMs),
+      r.throughput.toFixed(1) + " MB/s",
+    ]);
+  }
+
+  // Add full parse reference
+  const fullR = bench("full", (s) => streamdParse(s), streamSrc, 100, 500);
+  streamRows.push([
+    "@streamd (full parse)",
+    "1",
+    fmtMs(fullR.median),
+    "\u2014",
+    fullR.throughput.toFixed(1) + " MB/s",
+  ]);
+
+  printTable(streamRows);
+
+  // === Streaming at different chunk sizes (streamd only) ===
+  console.log("\n=== @streamd/parser Streaming by Chunk Size (50 KB) ===\n");
+
+  const csHeader = ["Chunk Size", "Chunks", "Total", "Per chunk (median)", "Throughput"];
+  const csRows: Array<Array<string>> = [csHeader];
+
+  for (const cs of [3, 10, 50, 200, 1000]) {
+    const r = benchStreamingFair(
+      cs + "B",
+      (acc, state) => streamdParse(acc, state as null).state,
+      streamSrc,
+      cs,
+      10,
+      30,
+    );
+    csRows.push([
+      cs + "B",
+      String(r.numChunks),
+      fmtMs(r.totalMedianMs),
+      fmtMs(r.perChunkMedianMs),
+      r.throughput.toFixed(1) + " MB/s",
+    ]);
+  }
+
+  printTable(csRows);
 }
 
 main();

--- a/packages/bench/src/profile-streaming.ts
+++ b/packages/bench/src/profile-streaming.ts
@@ -1,0 +1,157 @@
+/**
+ * Profile streaming paths — identifies where time is spent per chunk.
+ *
+ * Usage: npx tsx packages/bench/src/profile-streaming.ts
+ *
+ * @module bench/profile-streaming
+ */
+import { parse as streamdParse } from "@streamd/parser";
+import { generateMixed } from "./generate";
+
+function fmtNs(ns: number): string {
+  if (ns < 1000) return ns.toFixed(0) + " ns";
+  if (ns < 1_000_000) return (ns / 1000).toFixed(1) + " µs";
+  return (ns / 1_000_000).toFixed(2) + " ms";
+}
+
+interface ProfileResult {
+  label: string;
+  totalChunks: number;
+  medianNs: number;
+  p99Ns: number;
+  minNs: number;
+  maxNs: number;
+}
+
+function profileStreaming(
+  label: string,
+  src: string,
+  chunkSize: number,
+  warmup: number,
+  iterations: number,
+): ProfileResult {
+  const chunks: Array<string> = [];
+  for (let i = 0; i < src.length; i += chunkSize) {
+    chunks.push(src.slice(i, Math.min(i + chunkSize, src.length)));
+  }
+  const numChunks = chunks.length;
+
+  // Warmup
+  for (let w = 0; w < warmup; w++) {
+    let state: unknown = null;
+    let acc = "";
+    for (let c = 0; c < numChunks; c++) {
+      acc += chunks[c]!;
+      state = (streamdParse(acc, state as null) as { state: unknown }).state;
+    }
+  }
+
+  // Measure per-chunk times
+  const times: Array<number> = [];
+  for (let iter = 0; iter < iterations; iter++) {
+    let state: unknown = null;
+    let acc = "";
+    for (let c = 0; c < numChunks; c++) {
+      acc += chunks[c]!;
+      const t0 = performance.now();
+      state = (streamdParse(acc, state as null) as { state: unknown }).state;
+      const elapsed = (performance.now() - t0) * 1_000_000; // ns
+      times.push(elapsed);
+    }
+  }
+
+  times.sort((a, b) => a - b);
+  return {
+    label,
+    totalChunks: numChunks,
+    medianNs: times[Math.floor(times.length / 2)]!,
+    p99Ns: times[Math.floor(times.length * 0.99)]!,
+    minNs: times[0]!,
+    maxNs: times[times.length - 1]!,
+  };
+}
+
+function printResults(results: Array<ProfileResult>): void {
+  const rows: Array<Array<string>> = [["Scenario", "Chunks", "Median", "p99", "Min", "Max"]];
+  for (const r of results) {
+    rows.push([
+      r.label,
+      String(r.totalChunks),
+      fmtNs(r.medianNs),
+      fmtNs(r.p99Ns),
+      fmtNs(r.minNs),
+      fmtNs(r.maxNs),
+    ]);
+  }
+  const cols = rows[0]!.length;
+  const widths: Array<number> = [];
+  for (let c = 0; c < cols; c++) {
+    let max = 0;
+    for (const row of rows) {
+      if (row[c]!.length > max) max = row[c]!.length;
+    }
+    widths.push(max);
+  }
+  for (let r = 0; r < rows.length; r++) {
+    const cells = rows[r]!.map((cell, c) =>
+      c === 0 ? cell.padEnd(widths[c]!) : cell.padStart(widths[c]!),
+    );
+    console.log(`| ${cells.join(" | ")} |`);
+    if (r === 0) console.log(`|${widths.map((w) => "-".repeat(w + 2)).join("|")}|`);
+  }
+}
+
+// ── Plain text (text-append fast path) ────────────────────────
+console.log("=== Text-Append Fast Path (pure words, no newlines) ===\n");
+
+const plainText = "The quick brown fox jumps over the lazy dog and keeps running forever. ".repeat(
+  150,
+);
+printResults([
+  profileStreaming("3B chunks", plainText, 3, 20, 50),
+  profileStreaming("10B chunks", plainText, 10, 20, 50),
+  profileStreaming("50B chunks", plainText, 50, 20, 50),
+]);
+
+// ── Fenced code (fence-check fast path) ───────────────────────
+console.log("\n=== Fenced Code Fast Path ===\n");
+
+const codeBlock = "```js\n" + "const x = 1;\n".repeat(800) + "```\n";
+printResults([
+  profileStreaming("3B chunks", codeBlock, 3, 20, 50),
+  profileStreaming("10B chunks", codeBlock, 10, 20, 50),
+  profileStreaming("50B chunks", codeBlock, 50, 20, 50),
+]);
+
+// ── Paragraph with bold (inline re-parse) ─────────────────────
+console.log("\n=== Paragraph with Inline Formatting (re-parse path) ===\n");
+
+const boldPara = "This is text with **bold** and *italic* markers. ".repeat(200);
+printResults([
+  profileStreaming("1KB para, 50B", boldPara.slice(0, 1024), 50, 20, 100),
+  profileStreaming("5KB para, 50B", boldPara.slice(0, 5120), 50, 20, 50),
+  profileStreaming("10KB para, 50B", boldPara.slice(0, 10240), 50, 20, 30),
+]);
+
+// ── Mixed markdown (all paths) ────────────────────────────────
+console.log("\n=== Mixed Markdown (all fast paths) ===\n");
+
+printResults([
+  profileStreaming("1KB mixed, 3B", generateMixed(1), 3, 20, 100),
+  profileStreaming("10KB mixed, 50B", generateMixed(10), 50, 20, 50),
+  profileStreaming("50KB mixed, 50B", generateMixed(50), 50, 20, 30),
+]);
+
+// ── Newline-heavy paragraph (softbreak handling) ──────────────
+console.log("\n=== Paragraph with Newlines (softbreak tokens) ===\n");
+
+const newlinePara = "Line of text here\n".repeat(600);
+printResults([profileStreaming("10KB, 50B chunks", newlinePara.slice(0, 10240), 50, 20, 50)]);
+
+// ── concatTokens overhead ─────────────────────────────────────
+console.log("\n=== After Many Completed Blocks (concatTokens scaling) ===\n");
+
+// Many short blocks followed by streaming paragraph
+const manyBlocks = "# H\n\n".repeat(200) + "Streaming paragraph ";
+const manyBlocksSrc = manyBlocks + "word ".repeat(100);
+printResults([profileStreaming("200 completed + para, 5B", manyBlocksSrc, 5, 10, 50)]);

--- a/packages/bench/src/runner.ts
+++ b/packages/bench/src/runner.ts
@@ -48,3 +48,68 @@ export function printTable(label: string, results: Array<BenchResult>): void {
     );
   }
 }
+
+/** Result of a streaming benchmark run. */
+export interface StreamBenchResult {
+  name: string;
+  chunkSize: number;
+  totalMs: number;
+  perChunkMedianMs: number;
+  throughput: number;
+  numChunks: number;
+}
+
+/**
+ * Benchmark streaming parse — feeds source in chunks of `chunkSize` bytes.
+ * Measures per-chunk parse time individually for accurate median/p95.
+ */
+export function benchStreaming(
+  name: string,
+  parseFn: (src: string, state?: unknown) => { state: unknown },
+  src: string,
+  chunkSize: number,
+  warmup: number,
+  iterations: number,
+): StreamBenchResult {
+  const chunks: Array<string> = [];
+  for (let i = 0; i < src.length; i += chunkSize) {
+    chunks.push(src.slice(i, Math.min(i + chunkSize, src.length)));
+  }
+  const numChunks = chunks.length;
+
+  // Warmup
+  for (let w = 0; w < warmup; w++) {
+    let state: unknown = null;
+    let accumulated = "";
+    for (let c = 0; c < numChunks; c++) {
+      accumulated += chunks[c]!;
+      state = parseFn(accumulated, state).state;
+    }
+  }
+
+  // Measure: collect per-chunk times across all iterations
+  const chunkTimes: Array<number> = [];
+  const totalTimes: Array<number> = [];
+
+  for (let iter = 0; iter < iterations; iter++) {
+    const totalStart = performance.now();
+    let state: unknown = null;
+    let accumulated = "";
+    for (let c = 0; c < numChunks; c++) {
+      accumulated += chunks[c]!;
+      const t0 = performance.now();
+      state = parseFn(accumulated, state).state;
+      chunkTimes.push(performance.now() - t0);
+    }
+    totalTimes.push(performance.now() - totalStart);
+  }
+
+  chunkTimes.sort((a, b) => a - b);
+  totalTimes.sort((a, b) => a - b);
+
+  const totalMs = totalTimes[Math.floor(totalTimes.length / 2)]!;
+  const perChunkMedianMs = chunkTimes[Math.floor(chunkTimes.length / 2)]!;
+  const throughput = src.length / 1024 / 1024 / (totalMs / 1000);
+
+  return { name, chunkSize, totalMs, perChunkMedianMs, throughput, numChunks };
+}

--- a/packages/parser/src/index.test.ts
+++ b/packages/parser/src/index.test.ts
@@ -88,15 +88,12 @@ describe("parse", () => {
   });
 
   describe("streaming", () => {
-    it("should parse chunks incrementally", () => {
+    it("should parse incrementally with full source", () => {
       const { state: s1 } = parse("# Hello\n", null);
       expect(s1).toBeDefined();
 
-      const { tokens: t2, state: s2 } = parse("world\n", s1);
+      const { tokens: t2 } = parse("# Hello\nworld\n", s1);
       expect(t2.length).toBeGreaterThan(0);
-
-      const { tokens: t3 } = parse("", s2); // flush
-      expect(t3.length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/parser/src/parser.test.ts
+++ b/packages/parser/src/parser.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createParser, parse } from "./parser";
 import { TokenType } from "./types/token-type";
 
-describe("parse — full document", () => {
+describe("parse -- full document", () => {
   it("should parse empty string", () => {
     const { tokens, stableCount } = parse("");
     expect(tokens.length).toBe(0);
@@ -41,44 +41,236 @@ describe("parse — full document", () => {
   });
 });
 
-describe("parse — streaming", () => {
-  it("should parse chunks incrementally", () => {
+describe("parse -- streaming (full source API)", () => {
+  it("should parse incrementally with growing source", () => {
     const r1 = parse("# Hello\n");
-    const r2 = parse("World\n", r1.state);
+    const r2 = parse("# Hello\nWorld\n", r1.state);
     expect(r2.tokens.length).toBeGreaterThan(0);
-  });
-
-  it("should flush with empty string", () => {
-    const r1 = parse("# Hello\n");
-    const r2 = parse("", r1.state);
-    expect(r2.tokens.length).toBeGreaterThan(0);
-    expect(r2.stableCount).toBe(r2.tokens.length);
   });
 
   it("should handle incomplete lines", () => {
     const r1 = parse("# Hel");
-    const r2 = parse("lo\n", r1.state);
-    expect(r2.tokens.length).toBeGreaterThan(0);
-  });
-
-  it("should handle empty first chunk then content", () => {
-    const r1 = parse("");
     const r2 = parse("# Hello\n", r1.state);
     expect(r2.tokens.length).toBeGreaterThan(0);
   });
 
-  it("should handle chunk with no complete lines", () => {
+  it("should handle same source (no new content)", () => {
+    const r1 = parse("# Hello\n");
+    const r2 = parse("# Hello\n", r1.state);
+    expect(r2.tokens.length).toBeGreaterThan(0);
+  });
+
+  it("should handle source with no complete lines yet", () => {
     const r1 = parse("abc");
-    const r2 = parse("def", r1.state);
-    // No complete lines yet — should return empty or minimal
-    const r3 = parse("\n", r2.state);
+    const r2 = parse("abcdef", r1.state);
+    expect(r2.tokens.length).toBeGreaterThanOrEqual(0);
+    const r3 = parse("abcdef\n", r2.state);
     expect(r3.tokens.length).toBeGreaterThan(0);
   });
 
-  it("should return stableCount less than total for streaming", () => {
+  it("should return stableCount for completed blocks", () => {
     const r1 = parse("# Hello\n");
-    const r2 = parse("Para\n", r1.state);
+    const r2 = parse("# Hello\n\nPara\n", r1.state);
     expect(r2.stableCount).toBeLessThanOrEqual(r2.tokens.length);
+  });
+
+  it("should produce correct final tokens", () => {
+    const r1 = parse("# Title\n");
+    const r2 = parse("# Title\n\nParagraph\n", r1.state);
+    expect(r2.tokens.length).toBe(2);
+    expect(r2.tokens[0]?.type).toBe(TokenType.Heading);
+    expect(r2.tokens[1]?.type).toBe(TokenType.Paragraph);
+  });
+
+  it("should handle empty initial parse then content", () => {
+    const r1 = parse("");
+    const r2 = parse("# Hello\n", r1.state);
+    expect(r2.tokens.length).toBeGreaterThan(0);
+  });
+});
+
+describe("parse -- paragraph text-append fast path", () => {
+  it("should extend text token when appending pure words", () => {
+    // First call establishes a paragraph with a Text token
+    const r1 = parse("Hello ");
+    // Second call appends pure text (no special chars, no newline)
+    const r2 = parse("Hello world ", r1.state);
+    expect(r2.tokens.length).toBe(1);
+    expect(r2.tokens[0]?.type).toBe(TokenType.Paragraph);
+  });
+
+  it("should fall back to inline re-parse when special char appears", () => {
+    const r1 = parse("Hello ");
+    // Asterisk triggers delimiter handler — can't use text-append
+    const r2 = parse("Hello **bold** ", r1.state);
+    expect(r2.tokens.length).toBe(1);
+    expect(r2.tokens[0]?.type).toBe(TokenType.Paragraph);
+  });
+
+  it("should match full parse output for pure text streaming", () => {
+    const words = ["The ", "quick ", "brown ", "fox "];
+    let src = "";
+    let r = parse(src);
+    for (const w of words) {
+      src += w;
+      r = parse(src, r.state);
+    }
+    const full = parse(src);
+    expect(r.tokens.length).toBe(full.tokens.length);
+  });
+});
+
+describe("parse -- paragraph continuation fast path", () => {
+  it("should produce correct tokens when appending plain text to paragraph", () => {
+    const r1 = parse("Hello\n");
+    const r2 = parse("Hello\nworld\n", r1.state);
+    expect(r2.tokens.length).toBe(1);
+    expect(r2.tokens[0]?.type).toBe(TokenType.Paragraph);
+  });
+
+  it("should handle multiple appended lines of plain text", () => {
+    let src = "First line\n";
+    let r = parse(src);
+    for (const word of ["Second line\n", "Third line\n", "Fourth line\n"]) {
+      src += word;
+      r = parse(src, r.state);
+    }
+    expect(r.tokens.length).toBe(1);
+    expect(r.tokens[0]?.type).toBe(TokenType.Paragraph);
+  });
+
+  it("should fall back to full scan when heading interrupts paragraph", () => {
+    const r1 = parse("Hello\n");
+    const r2 = parse("Hello\n# Heading\n", r1.state);
+    // Heading interrupts the paragraph — both should be present
+    const types = r2.tokens.map((t) => t.type);
+    expect(types).toContain(TokenType.Heading);
+    expect(types).toContain(TokenType.Paragraph);
+  });
+
+  it("should fall back to full scan when blank line appears", () => {
+    const r1 = parse("Hello\n");
+    const r2 = parse("Hello\n\nWorld\n", r1.state);
+    expect(r2.tokens.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should fall back when blockquote interrupts paragraph", () => {
+    const r1 = parse("Hello\n");
+    const r2 = parse("Hello\n> quote\n", r1.state);
+    expect(r2.tokens.length).toBe(2);
+  });
+
+  it("should fall back when fenced code interrupts paragraph", () => {
+    const r1 = parse("Hello\n");
+    const r2 = parse("Hello\n```\ncode\n```\n", r1.state);
+    expect(r2.tokens.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("should preserve inline formatting in continued paragraph", () => {
+    const r1 = parse("Hello **bold\n");
+    const r2 = parse("Hello **bold** world\n", r1.state);
+    expect(r2.tokens.length).toBe(1);
+    expect(r2.tokens[0]?.type).toBe(TokenType.Paragraph);
+    const para = r2.tokens[0] as { children: Array<{ type: number }> };
+    const hasStrong = para.children.some((c) => c.type === TokenType.Strong);
+    expect(hasStrong).toBe(true);
+  });
+
+  it("should match full parse output for paragraph continuation", () => {
+    const src = "Hello\nworld\nfoo bar\n";
+    const full = parse(src);
+
+    let streaming = parse("Hello\n");
+    streaming = parse("Hello\nworld\n", streaming.state);
+    streaming = parse(src, streaming.state);
+
+    expect(streaming.tokens.length).toBe(full.tokens.length);
+    expect(streaming.tokens[0]?.type).toBe(full.tokens[0]?.type);
+  });
+});
+
+describe("parse -- fenced code continuation fast path", () => {
+  it("should produce code block when appending lines inside fence", () => {
+    const r1 = parse("```js\n");
+    const r2 = parse("```js\nconst x = 1;\n", r1.state);
+    expect(r2.tokens.length).toBeGreaterThanOrEqual(1);
+    const types = r2.tokens.map((t) => t.type);
+    expect(types).toContain(TokenType.CodeBlock);
+  });
+
+  it("should accumulate content across multiple chunks", () => {
+    let src = "```\n";
+    let r = parse(src);
+    for (const line of ["line 1\n", "line 2\n", "line 3\n"]) {
+      src += line;
+      r = parse(src, r.state);
+    }
+    const codeTokens = r.tokens.filter((t) => t.type === TokenType.CodeBlock);
+    expect(codeTokens.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should fall back when closing fence appears", () => {
+    let src = "```\ncode\n";
+    let r = parse(src);
+    src += "```\n";
+    r = parse(src, r.state);
+    const codeTokens = r.tokens.filter((t) => t.type === TokenType.CodeBlock);
+    expect(codeTokens.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should match full parse for unclosed fenced code", () => {
+    const src = "```js\nconst x = 1;\nconst y = 2;\n";
+    const full = parse(src);
+
+    let streaming = parse("```js\n");
+    streaming = parse("```js\nconst x = 1;\n", streaming.state);
+    streaming = parse(src, streaming.state);
+
+    expect(streaming.tokens.length).toBe(full.tokens.length);
+    const fullCode = full.tokens.find((t) => t.type === TokenType.CodeBlock);
+    const streamCode = streaming.tokens.find((t) => t.type === TokenType.CodeBlock);
+    expect(fullCode).toBeDefined();
+    expect(streamCode).toBeDefined();
+  });
+
+  it("should preserve language info in fast path", () => {
+    let src = "```typescript\n";
+    let r = parse(src);
+    src += "const x: number = 1;\n";
+    r = parse(src, r.state);
+    const code = r.tokens.find((t) => t.type === TokenType.CodeBlock) as
+      | { lang: string }
+      | undefined;
+    expect(code?.lang).toBe("typescript");
+  });
+});
+
+describe("parse -- math block continuation fast path", () => {
+  it("should produce math block when appending lines inside $$", () => {
+    const r1 = parse("$$\n", null, { math: true });
+    const r2 = parse("$$\nx + y\n", r1.state);
+    const types = r2.tokens.map((t) => t.type);
+    expect(types).toContain(TokenType.MathBlock);
+  });
+
+  it("should accumulate content across multiple chunks", () => {
+    let src = "$$\n";
+    let r = parse(src, null, { math: true });
+    for (const line of ["a + b\n", "c + d\n"]) {
+      src += line;
+      r = parse(src, r.state);
+    }
+    const mathTokens = r.tokens.filter((t) => t.type === TokenType.MathBlock);
+    expect(mathTokens.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should fall back when closing $$ appears", () => {
+    let src = "$$\nx\n";
+    let r = parse(src, null, { math: true });
+    src += "$$\n";
+    r = parse(src, r.state);
+    const mathTokens = r.tokens.filter((t) => t.type === TokenType.MathBlock);
+    expect(mathTokens.length).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -95,10 +287,10 @@ describe("createParser", () => {
     expect(tokens[0]?.type).toBe(TokenType.MathBlock);
   });
 
-  it("should support streaming via bound function", () => {
+  it("should support streaming", () => {
     const p = createParser();
-    const { state } = p("# Hello\n");
-    const { tokens } = p("", state);
-    expect(tokens.length).toBeGreaterThan(0);
+    const r1 = p("# Hello\n");
+    const r2 = p("# Hello\nWorld\n", r1.state);
+    expect(r2.tokens.length).toBeGreaterThan(0);
   });
 });

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -1,8 +1,8 @@
 /**
- * Core parser orchestrator — implements `parse()` and streaming.
+ * Core parser API — `parse()` and `createParser()`.
  *
- * Both full and streaming parse use the flat scan-to-completion architecture.
- * Streaming accumulates source chunks and re-scans the active region.
+ * Full document parsing is handled inline. Streaming is delegated
+ * to the `streaming/` module which implements incremental fast paths.
  *
  * @module parser
  */
@@ -10,52 +10,30 @@
 import type { AssembleOpts } from "./assembler/assemble";
 import { assemble } from "./assembler/assemble";
 import { scanBlocks } from "./scanner/block/scan";
-import type { Block } from "./scanner/block/types";
-import { CC_LF } from "./scanner/constants";
-import type { LinkReference } from "./types/internal";
+import { streamingParse } from "./streaming/incremental";
+import { createInitialState, type StreamState } from "./streaming/state";
 import type { ParseOptions, ParseResult, ParserState } from "./types/options";
-import type { Token } from "./types/tokens";
-
-/**
- * Internal streaming state — stored opaquely behind ParserState.
- *
- * Tracks accumulated source, completed blocks/tokens, and options
- * so that each new chunk only re-scans the active (last) block region.
- */
-interface StreamState {
-  source: string;
-  lastLineEnd: number;
-  opts: AssembleOpts;
-  /** Tokens from fully completed blocks (won't change). */
-  completedTokens: Array<Token>;
-  /** Flat blocks from the last scan — used for incremental re-scan. */
-  lastBlocks: Array<Block>;
-  /** RefMap accumulated from completed blocks. */
-  refMap: Map<string, LinkReference>;
-}
 
 /**
  * Parse markdown source into a token tree.
  *
- * @param src - Markdown source string (or chunk for streaming)
- * @param state - Previous parser state for streaming, null/undefined for full parse
- * @param options - Parser configuration (extensions, math, etc.)
+ * For streaming: pass the full accumulated source each time with the state
+ * from the previous call. No flush needed -- the last call's tokens are final.
+ *
+ * @param src - Full markdown source
+ * @param state - Previous state for streaming, null/undefined for one-shot
+ * @param options - Parser configuration
  */
 export function parse(
   src: string,
   state?: ParserState | null,
   options?: ParseOptions,
 ): ParseResult {
-  if (!state) {
-    return fullParse(src, options);
-  }
+  if (!state) return fullParse(src, options);
   return streamingParse(src, state as unknown as StreamState);
 }
 
-/**
- * Create a pre-configured parser with bound options.
- * Snapshots options at creation time — returns a bound parse function.
- */
+/** Create a pre-configured parser with bound options. */
 export function createParser(
   options?: ParseOptions,
 ): (src: string, state?: ParserState | null) => ParseResult {
@@ -63,9 +41,6 @@ export function createParser(
   return (src: string, state?: ParserState | null) => parse(src, state, frozenOptions);
 }
 
-/**
- * Resolved parser options — all flags explicitly set.
- */
 interface ResolvedOptions {
   math: boolean;
   tables: boolean;
@@ -74,7 +49,6 @@ interface ResolvedOptions {
   autolinks: boolean;
 }
 
-/** Resolve effective options — `gfm` flag enables sub-features. */
 function resolveOptions(options?: ParseOptions): ResolvedOptions {
   const gfm = options?.gfm ?? false;
   return {
@@ -86,7 +60,6 @@ function resolveOptions(options?: ParseOptions): ResolvedOptions {
   };
 }
 
-/** Build AssembleOpts from resolved options. */
 function toAssembleOpts(resolved: ResolvedOptions): AssembleOpts {
   return {
     math: resolved.math,
@@ -97,86 +70,16 @@ function toAssembleOpts(resolved: ResolvedOptions): AssembleOpts {
   };
 }
 
-/** Full document parse — no prior state. */
+/** Full document parse -- no prior state. */
 function fullParse(src: string, options?: ParseOptions): ParseResult {
   const resolved = resolveOptions(options);
   const opts = toAssembleOpts(resolved);
   const blocks = scanBlocks(src, opts.math, opts.tables, opts.taskListItems);
   const tokens = assemble(src, blocks, opts);
 
-  const streamState: StreamState = {
-    source: src,
-    lastLineEnd: src.length,
-    opts,
-    completedTokens: [],
-    lastBlocks: blocks,
-    refMap: new Map(),
-  };
-
   return {
     tokens,
     stableCount: tokens.length,
-    state: streamState as unknown as ParserState,
-  };
-}
-
-/** Streaming parse — continue from prior state. */
-function streamingParse(src: string, state: StreamState): ParseResult {
-  const opts = state.opts;
-
-  // Flush: empty string = finalize
-  if (src.length === 0) {
-    // Re-scan the full accumulated source for final output
-    const blocks = scanBlocks(state.source, opts.math, opts.tables, opts.taskListItems);
-    const tokens = assemble(state.source, blocks, opts);
-    return {
-      tokens,
-      stableCount: tokens.length,
-      state: state as unknown as ParserState,
-    };
-  }
-
-  // Append chunk to accumulated source
-  const prevSource = state.source;
-  state.source = prevSource.length > 0 ? prevSource + src : src;
-  const fullSrc = state.source;
-
-  // Find last complete line boundary
-  let lastComplete = fullSrc.length;
-  if (lastComplete > 0 && fullSrc.charCodeAt(lastComplete - 1) !== CC_LF) {
-    // Incomplete line at end — find the last newline
-    const lastNL = fullSrc.lastIndexOf("\n");
-    if (lastNL >= 0) {
-      lastComplete = lastNL + 1;
-    } else {
-      lastComplete = 0;
-    }
-  }
-
-  // Only scan complete lines
-  const scanSrc = lastComplete > 0 ? fullSrc.slice(0, lastComplete) : "";
-  state.lastLineEnd = lastComplete;
-
-  if (scanSrc.length === 0) {
-    return {
-      tokens: [],
-      stableCount: 0,
-      state: state as unknown as ParserState,
-    };
-  }
-
-  const blocks = scanBlocks(scanSrc, opts.math, opts.tables, opts.taskListItems);
-  const tokens = assemble(scanSrc, blocks, opts);
-
-  // stableCount: all blocks except the last one are stable
-  // (the last block might continue with the next chunk)
-  const stableCount = blocks.length > 0 ? Math.max(0, tokens.length - 1) : 0;
-
-  state.lastBlocks = blocks;
-
-  return {
-    tokens,
-    stableCount,
-    state: state as unknown as ParserState,
+    state: createInitialState(src.length, opts) as unknown as ParserState,
   };
 }

--- a/packages/parser/src/streaming/fast-path.test.ts
+++ b/packages/parser/src/streaming/fast-path.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for streaming fast-path checks.
+ *
+ * @module streaming/fast-path.test
+ */
+import { describe, expect, it } from "vitest";
+import {
+  extractFencedContent,
+  findLineStart,
+  hasFenceClose,
+  hasMathClose,
+  isParagraphContinuation,
+  isPlainTextAppend,
+} from "./fast-path";
+
+describe("isParagraphContinuation", () => {
+  it("should return true for plain text continuation", () => {
+    const src = "Hello\nworld\n";
+    expect(isParagraphContinuation(src, 6, 12, false)).toBe(true);
+  });
+
+  it("should return false when blank line appears", () => {
+    const src = "Hello\n\nworld\n";
+    expect(isParagraphContinuation(src, 6, 13, false)).toBe(false);
+  });
+
+  it("should return false when heading marker appears", () => {
+    const src = "Hello\n# Heading\n";
+    expect(isParagraphContinuation(src, 6, 16, false)).toBe(false);
+  });
+
+  it("should return false for blockquote marker", () => {
+    const src = "Hello\n> quote\n";
+    expect(isParagraphContinuation(src, 6, 14, false)).toBe(false);
+  });
+
+  it("should return false for setext underline", () => {
+    const src = "Hello\n===\n";
+    expect(isParagraphContinuation(src, 6, 10, false)).toBe(false);
+  });
+
+  it("should allow indent >= 4 as lazy continuation", () => {
+    const src = "Hello\n    indented\n";
+    expect(isParagraphContinuation(src, 6, 19, false)).toBe(true);
+  });
+});
+
+describe("isPlainTextAppend", () => {
+  it("should return true for plain words", () => {
+    const src = "Hello world";
+    expect(isPlainTextAppend(src, 6, 11, false, false, false)).toBe(true);
+  });
+
+  it("should return false when asterisk present", () => {
+    const src = "Hello *bold*";
+    expect(isPlainTextAppend(src, 6, 12, false, false, false)).toBe(false);
+  });
+
+  it("should return false when backtick present", () => {
+    const src = "Hello `code`";
+    expect(isPlainTextAppend(src, 6, 12, false, false, false)).toBe(false);
+  });
+
+  it("should return false when newline present", () => {
+    const src = "Hello\nworld";
+    expect(isPlainTextAppend(src, 5, 11, false, false, false)).toBe(false);
+  });
+
+  it("should return false for dollar when math enabled", () => {
+    const src = "Hello $x$";
+    expect(isPlainTextAppend(src, 6, 9, true, false, false)).toBe(false);
+  });
+
+  it("should return true for dollar when math disabled", () => {
+    const src = "Hello $5";
+    expect(isPlainTextAppend(src, 6, 8, false, false, false)).toBe(true);
+  });
+});
+
+describe("hasFenceClose", () => {
+  it("should detect backtick closing fence", () => {
+    const src = "```\ncode\n```\n";
+    expect(hasFenceClose(src, 9, 13, 0x60, 3)).toBe(true);
+  });
+
+  it("should not detect fence with fewer backticks", () => {
+    const src = "```\ncode\n``\n";
+    expect(hasFenceClose(src, 9, 12, 0x60, 3)).toBe(false);
+  });
+
+  it("should detect tilde closing fence", () => {
+    const src = "~~~\ncode\n~~~\n";
+    expect(hasFenceClose(src, 9, 13, 0x7e, 3)).toBe(true);
+  });
+});
+
+describe("hasMathClose", () => {
+  it("should detect closing $$", () => {
+    const src = "$$\nx\n$$\n";
+    expect(hasMathClose(src, 5, 8)).toBe(true);
+  });
+
+  it("should not detect single $", () => {
+    const src = "$$\nx\n$\n";
+    expect(hasMathClose(src, 5, 7)).toBe(false);
+  });
+});
+
+describe("extractFencedContent", () => {
+  it("should append newline if missing", () => {
+    expect(extractFencedContent("abc", 0, 3)).toBe("abc\n");
+  });
+
+  it("should not double newline", () => {
+    expect(extractFencedContent("abc\n", 0, 4)).toBe("abc\n");
+  });
+
+  it("should handle empty content", () => {
+    expect(extractFencedContent("", 0, 0)).toBe("");
+  });
+});
+
+describe("findLineStart", () => {
+  it("should return 0 for offset 0", () => {
+    expect(findLineStart("abc", 0)).toBe(0);
+  });
+
+  it("should return offset when preceded by LF", () => {
+    expect(findLineStart("abc\ndef", 4)).toBe(4);
+  });
+
+  it("should back up to line start", () => {
+    expect(findLineStart("abc\ndef", 6)).toBe(4);
+  });
+});

--- a/packages/parser/src/streaming/fast-path.ts
+++ b/packages/parser/src/streaming/fast-path.ts
@@ -1,0 +1,190 @@
+/**
+ * Streaming fast-path checks — gatekeepers for O(K) optimizations.
+ *
+ * Each function scans only the new content (from prevLen forward) to
+ * determine if the active block continues without structural change.
+ * All checks are conservative: false negatives fall back to the full
+ * scan path with no correctness impact.
+ *
+ * @module streaming/fast-path
+ */
+
+import { countIndent, findLineEndFast, isBlankRange, nextLine } from "../scanner/block/utils";
+import {
+  CC_0,
+  CC_9,
+  CC_BACKTICK,
+  CC_DASH,
+  CC_DOLLAR,
+  CC_EQ,
+  CC_GT,
+  CC_HASH,
+  CC_LF,
+  CC_LT,
+  CC_PIPE,
+  CC_PLUS,
+  CC_SPACE,
+  CC_STAR,
+  CC_TAB,
+  CC_TILDE,
+  CC_UNDERSCORE,
+} from "../scanner/constants";
+import { selectDispatch } from "../scanner/inline/dispatch";
+
+/** Reusable indent result for continuation checks. */
+const IND = { indent: 0, pos: 0 };
+
+/**
+ * Check if new lines are all paragraph continuation — no blank lines,
+ * no block-start markers, no setext underlines.
+ */
+export function isParagraphContinuation(
+  src: string,
+  prevLen: number,
+  lastComplete: number,
+  math: boolean,
+): boolean {
+  let pos = findLineStart(src, prevLen);
+
+  while (pos < lastComplete) {
+    const le = findLineEndFast(src, pos);
+    if (isBlankRange(src, pos, le)) return false;
+
+    countIndent(src, pos, le, IND);
+    if (IND.indent < 4) {
+      const fns = IND.pos;
+      if (fns < le && isBlockStartChar(src.charCodeAt(fns), math)) return false;
+      if (fns < le) {
+        const ch = src.charCodeAt(fns);
+        if ((ch === CC_EQ || ch === CC_DASH) && isSetextLine(src, fns, le, ch)) return false;
+      }
+    }
+
+    pos = nextLine(src, le);
+  }
+
+  return true;
+}
+
+/**
+ * Check if new content (prevLen to srcLen) is plain text — no inline-special
+ * characters that would trigger delimiter/link/entity/etc. handlers.
+ *
+ * When true AND the previous paragraph ended with a Text token, we can
+ * extend that token's content string instead of re-parsing all inlines.
+ * True O(K) for the common LLM word-append case.
+ */
+export function isPlainTextAppend(
+  src: string,
+  prevLen: number,
+  srcLen: number,
+  math: boolean,
+  autolinks: boolean,
+  strikethrough: boolean,
+): boolean {
+  const dispatch = selectDispatch(math, autolinks, strikethrough);
+  for (let i = prevLen; i < srcLen; i++) {
+    const code = src.charCodeAt(i);
+    if (code < 128 && dispatch[code] !== 0) return false;
+  }
+  return true;
+}
+
+/**
+ * Check if new lines contain a closing fence for a fenced code block.
+ * Only scans lines starting from prevLen — O(K).
+ */
+export function hasFenceClose(
+  src: string,
+  prevLen: number,
+  lastComplete: number,
+  fenceChar: number,
+  fenceLen: number,
+): boolean {
+  let pos = findLineStart(src, prevLen);
+  while (pos < lastComplete) {
+    const le = findLineEndFast(src, pos);
+    countIndent(src, pos, le, IND);
+    if (IND.indent < 4) {
+      let cp = IND.pos;
+      let cl = 0;
+      while (cp < le && src.charCodeAt(cp) === fenceChar) {
+        cl++;
+        cp++;
+      }
+      if (cl >= fenceLen && isBlankRange(src, cp, le)) return true;
+    }
+    pos = nextLine(src, le);
+  }
+  return false;
+}
+
+/**
+ * Check if new lines contain a closing $$ for a math block.
+ * Only scans lines starting from prevLen — O(K).
+ */
+export function hasMathClose(src: string, prevLen: number, lastComplete: number): boolean {
+  let pos = findLineStart(src, prevLen);
+  while (pos < lastComplete) {
+    const le = findLineEndFast(src, pos);
+    countIndent(src, pos, le, IND);
+    if (
+      IND.pos + 1 < le &&
+      src.charCodeAt(IND.pos) === CC_DOLLAR &&
+      src.charCodeAt(IND.pos + 1) === CC_DOLLAR
+    ) {
+      let cp = IND.pos + 2;
+      while (cp < le && (src.charCodeAt(cp) === CC_SPACE || src.charCodeAt(cp) === CC_TAB)) cp++;
+      if (cp >= le) return true;
+    }
+    pos = nextLine(src, le);
+  }
+  return false;
+}
+
+/** Extract fenced code content, appending trailing newline if needed. */
+export function extractFencedContent(
+  src: string,
+  contentStart: number,
+  contentEnd: number,
+): string {
+  const content = src.slice(contentStart, contentEnd);
+  if (content.length > 0 && content.charCodeAt(content.length - 1) !== CC_LF) {
+    return content + "\n";
+  }
+  return content;
+}
+
+/** Find the start of the line containing offset. */
+export function findLineStart(src: string, offset: number): number {
+  if (offset <= 0) return 0;
+  if (src.charCodeAt(offset - 1) === CC_LF) return offset;
+  let p = offset - 1;
+  while (p > 0 && src.charCodeAt(p - 1) !== CC_LF) p--;
+  return p;
+}
+
+/** Check if a character could start a new block that interrupts a paragraph. */
+function isBlockStartChar(ch: number, math: boolean): boolean {
+  if (ch === CC_HASH) return true;
+  if (ch === CC_BACKTICK || ch === CC_TILDE) return true;
+  if (ch === CC_GT) return true;
+  if (ch === CC_LT) return true;
+  if (ch === CC_PIPE) return true;
+  if (ch === CC_DASH || ch === CC_STAR || ch === CC_PLUS || ch === CC_UNDERSCORE) return true;
+  if (ch >= CC_0 && ch <= CC_9) return true;
+  if (math && ch === CC_DOLLAR) return true;
+  return false;
+}
+
+/** Check if a line is a setext underline. */
+function isSetextLine(src: string, fns: number, lineEnd: number, ch: number): boolean {
+  let p = fns + 1;
+  while (p < lineEnd && src.charCodeAt(p) === ch) p++;
+  while (p < lineEnd) {
+    const c = src.charCodeAt(p);
+    if (c !== CC_SPACE && c !== CC_TAB) return false;
+    p++;
+  }
+  return true;
+}

--- a/packages/parser/src/streaming/incremental.ts
+++ b/packages/parser/src/streaming/incremental.ts
@@ -1,0 +1,351 @@
+/**
+ * Incremental streaming parse — the core streaming logic.
+ *
+ * Handles block promotion, fast-path dispatch, and speculative
+ * assembly of the active block region.
+ *
+ * Fast paths (checked in order):
+ * 1. Fenced code continuation — O(K) scan for closing fence only
+ * 2. Math block continuation — O(K) scan for closing $$ only
+ * 3. Paragraph text append — O(K) extend last Text token
+ * 4. Paragraph continuation — skip block scan, re-parse inlines
+ *
+ * @module streaming/incremental
+ */
+
+import type { AssembleOpts } from "../assembler/assemble";
+import { assembleBlock, extractAllLinkRefDefs } from "../assembler/assemble";
+import { scanBlocks } from "../scanner/block/scan";
+import { BlockKind } from "../scanner/block/types";
+import { CC_CR, CC_DOLLAR, CC_LF, CC_SPACE, CC_TAB } from "../scanner/constants";
+import { parseInlines } from "../scanner/inline/scan";
+import type { ParseResult, ParserState } from "../types/options";
+import { TokenType } from "../types/token-type";
+import type { InlineToken, ParagraphToken, Token } from "../types/tokens";
+import {
+  createCodeBlockToken,
+  createMathBlockToken,
+  createParagraphToken,
+  createTextToken,
+} from "../utils/token-factory";
+import {
+  extractFencedContent,
+  hasFenceClose,
+  hasMathClose,
+  isParagraphContinuation,
+  isPlainTextAppend,
+} from "./fast-path";
+import { resetActiveState, type StreamState } from "./state";
+
+/**
+ * Incremental streaming parse.
+ *
+ * Caller passes the full accumulated source. Parser compares length
+ * against previous call to detect new content, then applies fast paths
+ * or falls back to scanning the active block region.
+ */
+export function streamingParse(src: string, state: StreamState): ParseResult {
+  const opts = state.opts;
+
+  // Short-circuit: no new content — re-assemble active region only
+  if (src.length <= state.prevLen) {
+    return buildResult(state, scanActive(src, state));
+  }
+
+  const prevLen = state.prevLen;
+  state.prevLen = src.length;
+
+  // ── Pre-line-boundary fast paths (work even without complete lines) ──
+
+  // Fast path 0: paragraph text append — O(K)
+  if (
+    state.activeBlockKind === BlockKind.Paragraph &&
+    state.activeInlines &&
+    state.activeInlines.length > 0 &&
+    isPlainTextAppend(src, prevLen, src.length, opts.math, opts.autolinks, opts.strikethrough)
+  ) {
+    const lastInline = state.activeInlines[state.activeInlines.length - 1]!;
+    if (lastInline.type === TokenType.Text) {
+      const newText = (lastInline as { content: string }).content + src.slice(prevLen);
+      // Single-token fast path: avoid array clone — just create [TextToken]
+      const inlines =
+        state.activeInlines.length === 1
+          ? SINGLE_TEXT_INLINES(newText)
+          : cloneInlinesWithNewLastText(state.activeInlines, newText);
+      state.activeInlines = inlines;
+      const para = createParagraphToken(inlines);
+      // Avoid concatTokens when no completed tokens
+      if (state.completedTokens.length === 0) {
+        return {
+          tokens: SINGLE_TOKEN(para),
+          stableCount: 0,
+          state: state as unknown as ParserState,
+        };
+      }
+      return buildResult(state, SINGLE_TOKEN(para));
+    }
+  }
+
+  // Fast path 1: fenced code continuation — O(K)
+  // Check against src.length (not lastComplete) so mid-line chunks inside
+  // code blocks don't fall through to the expensive scanActive path.
+  if (
+    state.activeBlockKind === BlockKind.FencedCode &&
+    state.activeContentStart > 0 &&
+    !hasFenceClose(src, prevLen, src.length, state.activeFenceChar, state.activeFenceLen)
+  ) {
+    const content = extractFencedContent(src, state.activeContentStart, src.length);
+    return buildResult(state, [createCodeBlockToken(state.activeLang, state.activeInfo, content)]);
+  }
+
+  // Fast path 2: math block continuation — O(K)
+  if (
+    state.activeBlockKind === BlockKind.MathBlock &&
+    state.activeContentStart > 0 &&
+    !hasMathClose(src, prevLen, src.length)
+  ) {
+    const content = src.slice(state.activeContentStart, src.length);
+    return buildResult(state, [createMathBlockToken(content)]);
+  }
+
+  // ── Line-boundary-dependent paths ──
+
+  // Find last complete line boundary
+  let lastComplete = src.length;
+  if (lastComplete > 0 && src.charCodeAt(lastComplete - 1) !== CC_LF) {
+    const lastNL = src.lastIndexOf("\n");
+    lastComplete = lastNL >= 0 ? lastNL + 1 : 0;
+  }
+
+  // Short-circuit: no complete lines past active block start
+  if (lastComplete <= state.activeBlockStart) {
+    const activeTokens = scanActive(src, state);
+    cacheActiveInlines(state, activeTokens);
+    return buildResult(state, activeTokens);
+  }
+
+  // Paragraph fast paths (3 & 4) — require complete lines for block-start check
+  if (
+    state.activeBlockKind === BlockKind.Paragraph &&
+    state.activeContentStart > 0 &&
+    isParagraphContinuation(src, prevLen, lastComplete, opts.math)
+  ) {
+    // Fast path 3: pure text append with complete lines — O(K)
+    if (
+      state.activeInlines &&
+      state.activeInlines.length > 0 &&
+      isPlainTextAppend(src, prevLen, lastComplete, opts.math, opts.autolinks, opts.strikethrough)
+    ) {
+      const lastInline = state.activeInlines[state.activeInlines.length - 1]!;
+      if (lastInline.type === TokenType.Text) {
+        const newText =
+          (lastInline as { content: string }).content + src.slice(prevLen, lastComplete);
+        const extended = cloneInlinesWithNewLastText(state.activeInlines, newText);
+        state.activeInlines = extended;
+        return buildResult(state, [createParagraphToken(extended)]);
+      }
+    }
+
+    // Fast path 4: paragraph continuation — skip block scan, re-parse inlines
+    const inlines = parseInlines(
+      src,
+      state.activeContentStart,
+      lastComplete,
+      state.refMap,
+      opts.math,
+      opts.autolinks,
+      opts.strikethrough,
+    );
+    state.activeInlines = inlines;
+    return buildResult(state, [createParagraphToken(inlines)]);
+  }
+
+  // Full active region scan
+  return scanActiveRegion(src, state, opts, lastComplete);
+}
+
+/**
+ * Clone inline tokens with the last Text token replaced by new content.
+ * All tokens before the last are reused by reference (immutable).
+ * O(1) for the common case of a single Text token.
+ */
+function cloneInlinesWithNewLastText(
+  inlines: Array<InlineToken>,
+  newText: string,
+): Array<InlineToken> {
+  const len = inlines.length;
+  // Fast path: single token — avoid array allocation
+  if (len === 1) return [createTextToken(newText)];
+  const out = new Array<InlineToken>(len);
+  for (let i = 0; i < len - 1; i++) out[i] = inlines[i]!;
+  out[len - 1] = createTextToken(newText);
+  return out;
+}
+
+/** Full active region scan — used when fast paths don't apply. */
+function scanActiveRegion(
+  src: string,
+  state: StreamState,
+  opts: AssembleOpts,
+  lastComplete: number,
+): ParseResult {
+  const activeSrc = src.slice(state.activeBlockStart, lastComplete);
+  const activeBlocks = scanBlocks(activeSrc, opts.math, opts.tables, opts.taskListItems);
+
+  if (activeBlocks.length === 0) {
+    resetActiveState(state);
+    return buildResult(state, []);
+  }
+
+  // Promote all blocks except the last to completed
+  if (activeBlocks.length > 1) {
+    const lastIdx = activeBlocks.length - 1;
+    const consumed = extractAllLinkRefDefs(activeSrc, activeBlocks, state.refMap);
+    for (let i = 0; i < lastIdx; i++) {
+      if (consumed.has(i)) continue;
+      const t = assembleBlock(activeSrc, activeBlocks[i]!, state.refMap, opts);
+      if (t) state.completedTokens.push(t);
+    }
+
+    const lastPromoted = activeBlocks[lastIdx - 1]!;
+    let newStart = state.activeBlockStart + lastPromoted.end;
+    while (newStart < src.length) {
+      const ch = src.charCodeAt(newStart);
+      if (ch === CC_LF) {
+        newStart++;
+        break;
+      }
+      if (ch !== CC_CR && ch !== CC_SPACE && ch !== CC_TAB) break;
+      newStart++;
+    }
+    state.activeBlockStart = newStart;
+  }
+
+  // Cache the last active block's metadata for next call's fast paths
+  const lastBlock = activeBlocks[activeBlocks.length - 1]!;
+  state.activeBlockKind = lastBlock.kind;
+  const absContentStart = state.activeBlockStart + lastBlock.contentStart;
+
+  if (lastBlock.kind === BlockKind.Paragraph) {
+    state.activeContentStart = absContentStart;
+    state.activeFenceChar = 0;
+    state.activeFenceLen = 0;
+    state.activeLang = "";
+    state.activeInfo = "";
+    state.activeInlines = null;
+  } else if (lastBlock.kind === BlockKind.FencedCode) {
+    state.activeContentStart = absContentStart;
+    state.activeFenceChar = lastBlock.fenceChar;
+    state.activeFenceLen = lastBlock.fenceLength;
+    state.activeLang = lastBlock.lang;
+    state.activeInfo = lastBlock.info;
+    state.activeInlines = null;
+  } else if (lastBlock.kind === BlockKind.MathBlock) {
+    state.activeContentStart = absContentStart;
+    state.activeFenceChar = CC_DOLLAR;
+    state.activeFenceLen = 2;
+    state.activeLang = "";
+    state.activeInfo = "";
+    state.activeInlines = null;
+  } else {
+    resetActiveState(state);
+    state.activeBlockKind = lastBlock.kind;
+  }
+
+  const activeTokens = assembleActive(src, state, opts);
+
+  // Cache inlines if the active block is a paragraph
+  if (
+    state.activeBlockKind === BlockKind.Paragraph &&
+    activeTokens.length === 1 &&
+    activeTokens[0]!.type === TokenType.Paragraph
+  ) {
+    state.activeInlines = (activeTokens[0] as ParagraphToken).children;
+  }
+
+  return buildResult(state, activeTokens);
+}
+
+/** Scan and assemble the active region (from activeBlockStart to end of src). */
+function scanActive(src: string, state: StreamState): Array<Token> {
+  if (state.activeBlockStart >= src.length) return [];
+  const activeSrc = src.slice(state.activeBlockStart);
+  const blocks = scanBlocks(
+    activeSrc,
+    state.opts.math,
+    state.opts.tables,
+    state.opts.taskListItems,
+  );
+  if (blocks.length === 0) return [];
+  const tempRefMap = new Map(state.refMap);
+  const consumed = extractAllLinkRefDefs(activeSrc, blocks, tempRefMap);
+  const tokens: Array<Token> = [];
+  for (let i = 0; i < blocks.length; i++) {
+    if (consumed.has(i)) continue;
+    const t = assembleBlock(activeSrc, blocks[i]!, tempRefMap, state.opts);
+    if (t) tokens.push(t);
+  }
+  return tokens;
+}
+
+/** Assemble the active (last) block speculatively. */
+function assembleActive(src: string, state: StreamState, opts: AssembleOpts): Array<Token> {
+  if (state.activeBlockStart >= src.length) return [];
+  const activeSrc = src.slice(state.activeBlockStart);
+  const blocks = scanBlocks(activeSrc, opts.math, opts.tables, opts.taskListItems);
+  if (blocks.length === 0) return [];
+  const tempRefMap = new Map(state.refMap);
+  const consumed = extractAllLinkRefDefs(activeSrc, blocks, tempRefMap);
+  const tokens: Array<Token> = [];
+  for (let i = 0; i < blocks.length; i++) {
+    if (consumed.has(i)) continue;
+    const t = assembleBlock(activeSrc, blocks[i]!, tempRefMap, opts);
+    if (t) tokens.push(t);
+  }
+  return tokens;
+}
+
+/** Cache inlines from active tokens for the text-append fast path. */
+function cacheActiveInlines(state: StreamState, activeTokens: Array<Token>): void {
+  if (
+    activeTokens.length > 0 &&
+    activeTokens[activeTokens.length - 1]!.type === TokenType.Paragraph
+  ) {
+    state.activeInlines = (activeTokens[activeTokens.length - 1] as ParagraphToken).children;
+    state.activeBlockKind = BlockKind.Paragraph;
+    if (state.activeContentStart === 0 && activeTokens.length === 1) {
+      // First paragraph — content starts at activeBlockStart
+      state.activeContentStart = state.activeBlockStart;
+    }
+  }
+}
+
+/** Reusable single-element array for InlineToken — avoids allocation in text-append path. */
+function SINGLE_TEXT_INLINES(text: string): Array<InlineToken> {
+  return [createTextToken(text)];
+}
+
+/** Reusable single-element array for Token — avoids wrapper allocation. */
+function SINGLE_TOKEN(token: Token): Array<Token> {
+  return [token];
+}
+
+/** Build a ParseResult from completed tokens + active tokens. */
+function buildResult(state: StreamState, activeTokens: Array<Token>): ParseResult {
+  const tokens = concatTokens(state.completedTokens, activeTokens);
+  return {
+    tokens,
+    stableCount: state.completedTokens.length,
+    state: state as unknown as ParserState,
+  };
+}
+
+/** Concatenate two token arrays without mutation. */
+function concatTokens(a: Array<Token>, b: Array<Token>): Array<Token> {
+  if (b.length === 0) return a;
+  if (a.length === 0) return b;
+  const out = new Array<Token>(a.length + b.length);
+  for (let i = 0; i < a.length; i++) out[i] = a[i]!;
+  for (let i = 0; i < b.length; i++) out[a.length + i] = b[i]!;
+  return out;
+}

--- a/packages/parser/src/streaming/state.test.ts
+++ b/packages/parser/src/streaming/state.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for streaming state management.
+ *
+ * @module streaming/state.test
+ */
+import { describe, expect, it } from "vitest";
+import { BlockKind } from "../scanner/block/types";
+import { createInitialState, resetActiveState } from "./state";
+
+describe("createInitialState", () => {
+  it("should create state with correct defaults", () => {
+    const opts = {
+      math: false,
+      strikethrough: false,
+      autolinks: false,
+      tables: false,
+      taskListItems: false,
+    };
+    const state = createInitialState(100, opts);
+    expect(state.prevLen).toBe(100);
+    expect(state.opts).toBe(opts);
+    expect(state.completedTokens.length).toBe(0);
+    expect(state.activeBlockStart).toBe(0);
+    expect(state.activeBlockKind).toBe(BlockKind.Paragraph);
+    expect(state.activeContentStart).toBe(0);
+    expect(state.activeFenceChar).toBe(0);
+    expect(state.activeFenceLen).toBe(0);
+    expect(state.activeLang).toBe("");
+    expect(state.activeInfo).toBe("");
+    expect(state.activeInlines).toBeNull();
+  });
+});
+
+describe("resetActiveState", () => {
+  it("should reset all active fields to defaults", () => {
+    const opts = {
+      math: false,
+      strikethrough: false,
+      autolinks: false,
+      tables: false,
+      taskListItems: false,
+    };
+    const state = createInitialState(100, opts);
+    state.activeBlockKind = BlockKind.FencedCode;
+    state.activeContentStart = 50;
+    state.activeFenceChar = 0x60;
+    state.activeFenceLen = 3;
+    state.activeLang = "js";
+    state.activeInfo = "js";
+    state.activeInlines = [];
+
+    resetActiveState(state);
+
+    expect(state.activeBlockKind).toBe(BlockKind.Paragraph);
+    expect(state.activeContentStart).toBe(0);
+    expect(state.activeFenceChar).toBe(0);
+    expect(state.activeFenceLen).toBe(0);
+    expect(state.activeLang).toBe("");
+    expect(state.activeInfo).toBe("");
+    expect(state.activeInlines).toBeNull();
+  });
+});

--- a/packages/parser/src/streaming/state.ts
+++ b/packages/parser/src/streaming/state.ts
@@ -1,0 +1,67 @@
+/**
+ * Streaming state — tracks incremental parse progress between calls.
+ *
+ * Cached metadata about the active (last) block enables fast paths
+ * that skip block scanning and/or inline parsing when new content
+ * is a continuation of the current block.
+ *
+ * @module streaming/state
+ */
+
+import type { AssembleOpts } from "../assembler/assemble";
+import type { BlockKindValue } from "../scanner/block/types";
+import { BlockKind } from "../scanner/block/types";
+import type { LinkReference } from "../types/internal";
+import type { InlineToken, Token } from "../types/tokens";
+
+/** Internal streaming state persisted between parse calls. */
+export interface StreamState {
+  prevLen: number;
+  opts: AssembleOpts;
+  completedTokens: Array<Token>;
+  activeBlockStart: number;
+  refMap: Map<string, LinkReference>;
+  /** Kind of the last active block — enables fast paths. */
+  activeBlockKind: BlockKindValue;
+  /** Content start of the active block (offset into full source). */
+  activeContentStart: number;
+  /** Fence char code for fenced code / math blocks (0 if not applicable). */
+  activeFenceChar: number;
+  /** Fence length for fenced code blocks (0 if not applicable). */
+  activeFenceLen: number;
+  /** Language string for fenced code blocks. */
+  activeLang: string;
+  /** Info string for fenced code blocks. */
+  activeInfo: string;
+  /** Cached inline tokens from the last paragraph parse (for text-append fast path). */
+  activeInlines: Array<InlineToken> | null;
+}
+
+/** Create initial streaming state after a full parse. */
+export function createInitialState(srcLen: number, opts: AssembleOpts): StreamState {
+  return {
+    prevLen: srcLen,
+    opts,
+    completedTokens: [],
+    activeBlockStart: 0,
+    refMap: new Map(),
+    activeBlockKind: BlockKind.Paragraph,
+    activeContentStart: 0,
+    activeFenceChar: 0,
+    activeFenceLen: 0,
+    activeLang: "",
+    activeInfo: "",
+    activeInlines: null,
+  };
+}
+
+/** Reset active block state to defaults. */
+export function resetActiveState(state: StreamState): void {
+  state.activeBlockKind = BlockKind.Paragraph;
+  state.activeContentStart = 0;
+  state.activeFenceChar = 0;
+  state.activeFenceLen = 0;
+  state.activeLang = "";
+  state.activeInfo = "";
+  state.activeInlines = null;
+}


### PR DESCRIPTION
## Summary

Incremental streaming architecture that avoids re-parsing completed blocks. The parser diffs against the previous source length and only re-scans the active block region, with O(K) fast paths for the most common LLM streaming patterns.

## What changed

### Streaming module (`streaming/`)
- `state.ts` — `StreamState` interface with active block metadata caching
- `fast-path.ts` — Conservative gatekeeper functions that scan only new content
- `incremental.ts` — Fast-path cascade: text-append → fenced code → math → paragraph → full scan

### `parser.ts` — Thin API surface
Reduced to ~85 lines. All streaming complexity encapsulated in `streaming/`.

### Benchmarks
- `baseline.ts` — Static + streaming performance snapshot
- `profile-streaming.ts` — Per-path latency breakdown
- `index.ts` — Fair streaming comparison (all parsers get same accumulated string)
- `index.html` — Browser benchmark with configurable chunk size and iterations

### Design doc
Rewritten from first principles with HLD/LLD, complexity analysis, 10 critical design questions, and incremental inline architecture proposal for future O(K) paragraph inline parsing.

## Fast-path hierarchy

| Fast path | Condition | Complexity |
|-----------|-----------|------------|
| Text append | Paragraph + last inline is Text + no special chars | O(K) |
| Fenced code | No closing fence in new lines | O(K) |
| Math block | No closing `$$` in new lines | O(K) |
| Paragraph continuation | No block-start markers in new lines | O(K) block + O(N) inline |
| Full scan | Fallback | O(active region) |

## Benchmark results

### Static parse (unchanged — zero regression)
| Input | Throughput |
|-------|-----------|
| Mixed 1 KB | ~90 MB/s |
| Mixed 50 KB | ~100 MB/s |
| Mixed 500 KB | ~80 MB/s |

### Streaming (50KB mixed, 200B chunks)
| Parser | Total | Per chunk | Throughput |
|--------|-------|-----------|-----------|
| **@streamd/parser** | **1.1ms** | **4.0µs** | **43.9 MB/s** |
| commonmark.js | 161ms | 599µs | 0.3 MB/s |
| markdown-it | 201ms | 772µs | 0.2 MB/s |
| marked | 442ms | 1.7ms | 0.1 MB/s |

**145x faster than commonmark.js, 400x faster than marked** for the streaming use case.

### Streaming by content type (10KB, 50B chunks)
| Content | Per chunk |
|---------|-----------|
| Plain text (text-append fast path) | 417ns |
| Fenced code blocks | 541ns |
| Paragraphs with **bold** | 1.3µs |
| Mixed markdown | 1.9µs |

## Tests
509 tests across 31 files. All passing.
