### PR TITLE
fix(ci): make husky hooks POSIX-sh and skip hooks in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,3 +62,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
+          # Skip husky hooks on the auto-generated version-bump commit
+          # and the follow-up push to changeset-release/main. The full
+          # lint + banned-names + typecheck + build + test gate already
+          # ran in the steps above this one, so re-running them inside
+          # the hook would just duplicate CI work. More importantly,
+          # husky v9 dispatches hooks through `sh -e`, and any bashism
+          # in a contributor's future hook edit would break this
+          # automated commit path — skipping hooks here keeps the
+          # release job resilient to hook regressions.
+          HUSKY: "0"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,11 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Pre-commit hook — enforce steering rules before the commit lands.
+#
+# Husky v9 dispatches hooks through `sh -e`, ignoring the shebang. This
+# file must stay POSIX-sh compatible: no `set -o pipefail`, no
+# `IFS=$'\n\t'`, no `[[ ]]`. `set -eu` is POSIX-clean and sufficient —
+# none of the commands below use pipes, so pipefail was defense that
+# did nothing.
 #
 # Runs:
 #   1. lint-staged — biome check --write on staged files
@@ -9,8 +15,7 @@
 # Any failure blocks the commit. Use `git commit --no-verify` only in a
 # true emergency.
 
-set -euo pipefail
-IFS=$'\n\t'
+set -eu
 
 echo "pre-commit: lint-staged"
 npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,12 +1,17 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Pre-push hook — run the CI gate locally so broken pushes never leave
 # the machine. Pre-commit already handled lint-staged + banned-names +
 # typecheck; this adds build + full test suite.
 #
+# Husky v9 dispatches hooks through `sh -e`, ignoring the shebang. This
+# file must stay POSIX-sh compatible: no `set -o pipefail`, no
+# `IFS=$'\n\t'`, no `[[ ]]`. `set -eu` is POSIX-clean and sufficient —
+# none of the commands below use pipes, so pipefail was defense that
+# did nothing.
+#
 # Skip with --no-verify only in an emergency. Don't normalise that.
 
-set -euo pipefail
-IFS=$'\n\t'
+set -eu
 
 echo "pre-push: lint"
 npm run lint


### PR DESCRIPTION
## Problem

The `Release` workflow is failing at the `Create Release PR / Publish` step when `changesets/action@v1` runs `git commit`:

```
.husky/pre-commit: 12: set: Illegal option -o pipefail
husky - pre-commit script failed (code 2)
##[error]Error: The process '/usr/bin/git' failed with exit code 1
```

Failing runs: [#25530930334](https://github.com/KarthikMAM/streamd/actions/runs/25530930334), [#25525334521](https://github.com/KarthikMAM/streamd/actions/runs/25525334521).

## Root cause

Husky v9's dispatcher (`.husky/_/h`) runs user hooks with `sh -e "$s"` — unconditionally POSIX sh, ignoring the `#!/usr/bin/env bash` shebang on the hook file. On Ubuntu runners `sh` is `dash`, which rejects:

- `set -o pipefail`
- `IFS=$'\n\t'` (ANSI-C quoting)

Both `.husky/pre-commit` and `.husky/pre-push` use these bashisms. Neither hook actually uses pipes, so `pipefail` was defense that did nothing — `set -eu` alone is POSIX-clean and sufficient.

This is a real bug beyond CI: it would also break local commits on any machine where `sh` is `dash` (Debian/Ubuntu hosts, many containers).

## Fix

Two layers:

1. **POSIX-clean hooks.** Both hooks now use `#!/usr/bin/env sh` and `set -eu`. Verified locally with `sh -ex .husky/pre-commit` — the hook now executes past line 12 (accepts `set -eu`, runs `npx lint-staged`, etc.), where the old version died with "Illegal option -o pipefail".

2. **`HUSKY: 0` on the release Publish step.** Defense in depth. The full `lint + banned-names + typecheck + build + test` gate already runs in the earlier steps of the release job, so re-running them inside the hook on the auto-generated version-bump commit is just duplicate CI work. Skipping hooks here also makes the release job resilient to any future bashism a contributor might reintroduce into a hook.

## Verification

```console
$ sh -ex .husky/pre-commit
+ set -eu
+ echo 'pre-commit: lint-staged'
pre-commit: lint-staged
+ npx lint-staged
→ No staged files found.
+ echo 'pre-commit: banned-names scan'
```

The hook is past the old failure point and runs cleanly.