### PR TITLE
chore(release): downgrade plugin-abi changeset from major to minor

### DIFF
--- a/.changeset/plugins-abi-hardening.md
+++ b/.changeset/plugins-abi-hardening.md
@@ -1,5 +1,5 @@
 ---
-"@streamd/plugins": major
+"@streamd/plugins": minor
 ---
 
 Harden the plugin ABI and the `sanitize()` defense-in-depth layer. Four


### PR DESCRIPTION
## Why

Streamd is pre-1.0 — every package sits at `0.0.1` today. `@streamd/plugins` had a `major` changeset which, combined with the `linked` group in `.changeset/config.json`, would bump four packages (`@streamd/plugins`, `@streamd/cli`, `@streamd/plugin-shiki`, `@streamd/plugin-katex`) straight to `1.0.0` on the next release.

We're not ready to commit to a stable 1.0 API yet. For a pre-1.0 repo the convention is:

- Every release is a `minor` bump: `0.0.1 → 0.1.0 → 0.2.0 → ...`.
- Breaking changes get documented in the `minor` release notes. The whole `0.x` range is "unstable" by semver definition, so `major` has no meaning until the deliberate "we're stabilizing" moment.
- `major` is reserved for the intentional `1.0.0` cut.

## What this changes

One line in `.changeset/plugins-abi-hardening.md`: the bump type for `@streamd/plugins` goes from `major` to `minor`. The rich migration notes in the body stay — they still describe real breaking changes consumers need to see, just without the `major` semver claim attached.

## Version preview

After this merges, the `Release` workflow will regenerate PR #21 with:

| Package | Before this change | After this change |
|---|---|---|
| `@streamd/plugins` | 1.0.0 | **0.1.0** |
| `@streamd/cli` | 1.0.0 | **0.1.0** |
| `@streamd/plugin-shiki` | 1.0.0 | **0.1.0** |
| `@streamd/plugin-katex` | 1.0.0 | **0.1.0** |
| `@streamd/parser` | 0.0.1 | 0.0.1 |
| `@streamd/tokens` | 0.0.1 | 0.0.1 |
| `@streamd/html` | 0.0.1 | 0.0.1 |
| `@streamd/react` | 0.0.1 | 0.0.1 |
| `@streamd/react-native` | 0.0.1 | 0.0.1 |

Confirmed locally by running `npx changeset version` in a reset workspace and inspecting the computed `packages/*/package.json` versions before reverting.

## Why parser/tokens/html/react/react-native stay at 0.0.1

`linked` in changesets means "when any member of the group bumps, all bumped members snap to the same version" — it does not force a bump on packages that have no changeset. These five have no pending changesets in `.changeset/`, so they're correctly untouched. If you want them included in the 0.1.0 release, add a changeset naming them at whatever bump level you want before merging PR #21.